### PR TITLE
v1.3.0

### DIFF
--- a/cmd/qobuz-dl/main.go
+++ b/cmd/qobuz-dl/main.go
@@ -22,6 +22,7 @@ const usage = `Usage: qobuz-dl [options] <command> [args]
 Commands:
   dl  <URL...>       Download by URL (album/track/artist/label/playlist/last.fm)
   lucky <query>      Download first N search results
+  csv <file.csv>     Batch download from a TuneMyMusic CSV export
   oauth [code|url]   Login via OAuth (recommended)
   fun                Interactive search and download mode
 
@@ -45,6 +46,7 @@ Options:
   --smart-discog     Smart discography filter
   --lucky-type       Type for lucky command (album|track|artist|playlist)
   --lucky-n          Number of results for lucky command
+  --failed <file>    Output CSV for failed/not-found tracks (csv command, default: failed_downloads.csv)
 `
 
 func main() {
@@ -75,6 +77,7 @@ func main() {
 	smartDiscog := fs.Bool("smart-discog", false, "")
 	luckyType := fs.String("lucky-type", "album", "")
 	luckyN := fs.Int("lucky-n", 1, "")
+	failed := fs.String("failed", "failed_downloads.csv", "")
 
 	fs.Parse(os.Args[1:])
 
@@ -161,6 +164,17 @@ func main() {
 			fatalf("%v", err)
 		}
 		dl.DownloadURLs(urls)
+
+	case "csv":
+		if len(cmdArgs) == 0 {
+			fmt.Fprintln(os.Stderr, "csv: provide path to a TuneMyMusic CSV file")
+			os.Exit(1)
+		}
+		dl, err := initDownloader(ctx, *dir, *quality, *embedArt, *albumsOnly, *noM3U, *noFallback, *ogCover, *noCover, *noDB, *workers, *folderFmt, *trackFmt, *smartDiscog)
+		if err != nil {
+			fatalf("%v", err)
+		}
+		dl.DownloadCSV(cmdArgs[0], *failed)
 
 	case "oauth":
 		codeOrURL := ""

--- a/cmd/qobuz-dl/main.go
+++ b/cmd/qobuz-dl/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 // version is set at build time via -ldflags "-X main.version=v1.x.x".
-var version = "dev"
+var version = "v1.3.0"
 
 const usage = `Usage: qobuz-dl [options] <command> [args]
 

--- a/internal/downloader/csvbatch.go
+++ b/internal/downloader/csvbatch.go
@@ -1,0 +1,220 @@
+package downloader
+
+import (
+	"bufio"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// TrackRequest represents a single track parsed from a TuneMyMusic CSV export.
+type TrackRequest struct {
+	Title  string
+	Artist string
+	Album  string
+	ISRC   string
+	Query  string // search query sent to Qobuz
+	RowNum int
+	Raw    string // original "Track name" field value
+}
+
+// ParseCSV reads a TuneMyMusic CSV file and returns a slice of TrackRequests.
+// Expected header: Track name,Artist name,Album,Playlist name,Type,ISRC
+//
+// Handles the common TuneMyMusic anomaly where Artist name is empty and
+// Track name contains "Artist - Title" format.
+func ParseCSV(path string) ([]TrackRequest, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open csv: %w", err)
+	}
+	defer f.Close()
+
+	// Strip UTF-8 BOM (\xef\xbb\xbf) emitted by TuneMyMusic and Windows editors.
+	br := bufio.NewReader(f)
+	if bom, err := br.Peek(3); err == nil && bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF {
+		br.Discard(3)
+	}
+
+	r := csv.NewReader(br)
+	r.FieldsPerRecord = -1 // tolerate variable column counts
+	r.LazyQuotes = true
+
+	header, err := r.Read()
+	if err != nil {
+		return nil, fmt.Errorf("read header: %w", err)
+	}
+
+	colIdx := make(map[string]int, len(header))
+	for i, h := range header {
+		colIdx[strings.TrimSpace(h)] = i
+	}
+
+	// Warn if the critical column is missing — helps diagnose future format changes.
+	if _, ok := colIdx["Track name"]; !ok {
+		fmt.Fprintf(os.Stderr, "\033[33mWarning: 'Track name' column not found in header. Got: %v\033[0m\n", header)
+	}
+
+	get := func(record []string, name string) string {
+		i, ok := colIdx[name]
+		if !ok || i >= len(record) {
+			return ""
+		}
+		return strings.TrimSpace(record[i])
+	}
+
+	var tracks []TrackRequest
+	rowNum := 1
+	for {
+		record, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		rowNum++
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "\033[33m  [row %d] skipped: parse error: %v\033[0m\n", rowNum, err)
+			continue
+		}
+
+		raw := get(record, "Track name")
+		if raw == "" {
+			fmt.Fprintf(os.Stderr, "\033[33m  [row %d] skipped: empty Track name\033[0m\n", rowNum)
+			continue
+		}
+
+		artist := get(record, "Artist name")
+		title := raw
+		album := get(record, "Album")
+		isrc := get(record, "ISRC")
+
+		// TuneMyMusic anomaly: artist empty → infer from "Artist - Title" format.
+		if artist == "" {
+			if parts := strings.SplitN(raw, " - ", 2); len(parts) == 2 {
+				artist = strings.TrimSpace(parts[0])
+				title = strings.TrimSpace(parts[1])
+			}
+		}
+
+		var query string
+		if artist != "" {
+			query = artist + " " + title
+		} else {
+			query = title
+		}
+
+		tracks = append(tracks, TrackRequest{
+			Title:  title,
+			Artist: artist,
+			Album:  album,
+			ISRC:   isrc,
+			Query:  query,
+			RowNum: rowNum,
+			Raw:    raw,
+		})
+	}
+	return tracks, nil
+}
+
+type failedEntry struct {
+	Track  TrackRequest
+	Reason string
+}
+
+// DownloadCSV parses the CSV at csvPath and downloads each track via Qobuz.
+// If failedPath is non-empty, writes a CSV report of skipped/failed tracks there.
+func (d *Downloader) DownloadCSV(csvPath, failedPath string) {
+	tracks, err := ParseCSV(csvPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\033[31mCSV parse error: %v\033[0m\n", err)
+		return
+	}
+	if len(tracks) == 0 {
+		fmt.Println("No tracks found in CSV.")
+		return
+	}
+
+	fmt.Printf("\033[33mCSV loaded: %d tracks to process\033[0m\n\n", len(tracks))
+
+	total := len(tracks)
+	downloaded := 0
+	var failures []failedEntry
+	dir := d.Opts.Directory
+
+	for i, t := range tracks {
+		fmt.Printf("\033[33m[%d/%d] %s\033[0m\n", i+1, total, t.Query)
+
+		trackID, err := d.searchFirstTrackID(t.Query)
+		if err != nil {
+			fmt.Printf("  \033[31m✗ Search error: %v\033[0m\n", err)
+			failures = append(failures, failedEntry{t, fmt.Sprintf("search error: %v", err)})
+			continue
+		}
+		if trackID == "" {
+			fmt.Printf("  \033[31m✗ Not found on Qobuz\033[0m\n")
+			failures = append(failures, failedEntry{t, "not found"})
+			continue
+		}
+
+		fmt.Printf("  \033[32m→ id=%s, downloading...\033[0m\n", trackID)
+		if err := d.downloadTrackByID(trackID, dir); err != nil {
+			fmt.Printf("  \033[31m✗ Download error: %v\033[0m\n", err)
+			failures = append(failures, failedEntry{t, fmt.Sprintf("download error: %v", err)})
+			continue
+		}
+		downloaded++
+	}
+
+	printBatchSummary(total, downloaded, failures)
+
+	if failedPath != "" && len(failures) > 0 {
+		if err := writeFailedCSV(failedPath, failures); err != nil {
+			fmt.Fprintf(os.Stderr, "  \033[31mCould not write failed report: %v\033[0m\n", err)
+		} else {
+			fmt.Printf("  Failed tracks saved to: %s\n", failedPath)
+		}
+	}
+}
+
+func printBatchSummary(total, downloaded int, failures []failedEntry) {
+	notFound, errCount := 0, 0
+	for _, f := range failures {
+		if f.Reason == "not found" {
+			notFound++
+		} else {
+			errCount++
+		}
+	}
+	fmt.Printf("\n\033[1m=== CSV Batch Summary ===\033[0m\n")
+	fmt.Printf("  Total processed: %d\n", total)
+	fmt.Printf("  Downloaded:      \033[32m%d\033[0m\n", downloaded)
+	fmt.Printf("  Not found:       \033[33m%d\033[0m\n", notFound)
+	fmt.Printf("  Errors:          \033[31m%d\033[0m\n", errCount)
+}
+
+func writeFailedCSV(path string, entries []failedEntry) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	if err := w.Write([]string{"row", "artist", "title", "query", "reason"}); err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if err := w.Write([]string{
+			fmt.Sprintf("%d", e.Track.RowNum),
+			e.Track.Artist,
+			e.Track.Title,
+			e.Track.Query,
+			e.Reason,
+		}); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	return w.Error()
+}

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -724,11 +724,12 @@ func (d *Downloader) downloadWithProgress(rawURL, dest string, bar *mpb.Bar) err
 		}
 
 		// Server ignored Range and sent full file — discard partial data and restart.
+		// Must continue so we make a fresh request with the original (non-closed) body.
 		if offset > 0 && resp.StatusCode == http.StatusOK {
 			resp.Body.Close()
 			os.Remove(dest)
-			offset = 0
 			barCredited = 0
+			continue
 		}
 
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
@@ -753,7 +754,9 @@ func (d *Downloader) downloadWithProgress(rawURL, dest string, bar *mpb.Bar) err
 			}
 		}
 
-		// Initialise bar total as soon as we know it.
+		// Set bar total for display only — do NOT trigger auto-completion here.
+		// The bar is explicitly completed after io.Copy returns to avoid mpb
+		// closing its operateState channel while ProxyReader is still active.
 		if bar != nil && totalSize > 0 {
 			bar.SetTotal(totalSize, false)
 		}
@@ -798,12 +801,18 @@ func (d *Downloader) downloadWithProgress(rawURL, dest string, bar *mpb.Bar) err
 		written := offset + n
 
 		if copyErr == nil {
-			if bar != nil && totalSize <= 0 {
-				// Mark complete with actual bytes when Content-Length was absent.
-				bar.SetTotal(written, true)
-			}
 			if totalSize > 0 && written != totalSize {
 				return fmt.Errorf("incomplete download: got %d of %d bytes", written, totalSize)
+			}
+			// Explicitly mark bar complete now that io.Copy has fully returned.
+			// Doing this here (not during SetTotal) prevents mpb from closing its
+			// internal operateState channel while ProxyReader is still reading.
+			if bar != nil {
+				completedAt := totalSize
+				if completedAt <= 0 {
+					completedAt = written
+				}
+				bar.SetTotal(completedAt, true)
 			}
 			return nil
 		}


### PR DESCRIPTION
## Summary

   This release introduces **CSV batch downloading** — compatible with [TuneMyMusic](https://www.tunemymusic.com/) playlist exports — and resolves two critical stability bugs that caused silent hangs and panics on single-track
   downloads in all command modes (`dl`, `lucky`, `fun`).

   ---

   ##  New Features

   ### `csv` command — Batch download from a TuneMyMusic CSV export

   ```bash
   ./qobuz-dl csv playlist.csv -d ~/Music -q 27
   ./qobuz-dl csv playlist.csv --failed skipped.csv -q 6
   ```

   - **Smart CSV parsing** (`internal/downloader/csvbatch.go`): Handles the common TuneMyMusic anomaly where `Artist name`, `Album`, and `ISRC` columns are empty and the track appears as `"Artist - Title"` in the `Track name` field.
   The parser infers artist and title via a `" - "` split, then falls back to a full-string query if no separator is found.
   - **UTF-8 BOM stripping**: TuneMyMusic (and many Windows editors) prepend a `\xef\xbb\xbf` BOM that would otherwise corrupt the header column map and silently discard every row. The reader peeks and discards it before parsing.
   - **`--failed <file>` flag**: At the end of the batch run, tracks that were not found on Qobuz or failed to download are written to a structured CSV report (columns: `row`, `artist`, `title`, `query`, `reason`). Defaults to
   `failed_downloads.csv`.
   - **End-of-run summary**: Prints `Total processed / Downloaded / Not found / Errors` after the batch completes.

   ---

   ## 🐛 Critical Bug Fixes

   ### Fix: Silent hang / deadlock after every single-track download

   **Affected commands:** `dl` (single track URL), `lucky`, `fun`, and the new `csv` command.

   **Root cause:** `downloadWithProgress` called `mpb.Bar.SetTotal(n, false)` — the `false` flag tells mpb *"set the denominator for display but never auto-complete this bar"*. After a successful download, the bar reached 100% visually
    but was never marked done in mpb's internal state. `p.Wait()` in `downloadTrackByID` therefore blocked forever.

   **Fix:** `SetTotal` is now called with `triggerComplete=false` during initialisation (display only), and with `triggerComplete=true` **explicitly after `io.Copy` returns** — once the `ProxyReader` goroutine is no longer active.
   `p.Wait()` sees the bar as completed and returns immediately.

   ### Fix: Panic (`nil pointer dereference` in `io.Copy`) on retry after server ignores `Range`

   **Root cause — two compounding issues in `downloadWithProgress`:**

   1. **Missing `continue` in restart path:** When a server responds `200 OK` to a `Range` request (ignoring it and sending the full file), the code closed `resp.Body`, removed the partial file, and reset internal state — but then
   **fell through** and continued using the already-closed body in the same loop iteration. Subsequent use of the closed body caused undefined behavior.

   2. **Bar auto-completion during `io.Copy`:** The previous fix set `SetTotal(n, true)` at the top of the attempt, causing mpb to auto-complete the bar the moment `ProxyReader` fed the last byte — while `io.Copy` was still running and
    about to issue one final `Read` for EOF. mpb's `serve` goroutine closes its `operateState` channel on bar completion; the EOF-probe `IncrBy(0)` sent on the closed channel, producing a `nil pointer dereference` panic.

   **Fix:**
   - Added `continue` to the restart block so a fresh HTTP request is made on the next attempt.
   - Reverted `SetTotal` to `false` during initialisation; completion is now triggered explicitly after `io.Copy` returns cleanly.

   ---

   ## 🛠 Robustness & Graceful Degradation

   - The `csv` batch loop never calls `panic` or `log.Fatal`. Any per-track failure (search error, Qobuz API error, download error, track not found) is caught, logged inline, and the loop advances to the next row.
   - Row-skip warnings are printed to `stderr` when the CSV parser skips a row (malformed line, empty `Track name`), making format issues immediately visible without aborting the run.
   - A missing or unrecognised `Track name` column in the header emits a clear warning listing the actual columns found — prevents silent empty-result runs on unexpected CSV formats.





