### PR TITLE
v1.3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,12 +18,13 @@ internal/downloader/ Descarga, tagging FLAC/MP3, colecciones, OAuth
 Solo stdlib de Go. El tagging FLAC (Vorbis Comment) y MP3 (ID3v2.3) están
 implementados en Go puro en `internal/downloader/metadata.go`.
 
-## Estado actual
+## Estado actual (v1.3.0)
 
 - `go build ./...` ✅
 - `go vet ./...` ✅
 - `go test ./...` ✅ (todos los paquetes pasan)
 - Cobertura: api 42%, bundle 64%, config 46%, downloader 25%
+- Rama de release pendiente de PR: `release/v1.3.0` (push hecho, `gh` CLI no instalado en la máquina)
 
 ## Autenticación Qobuz (abril 2026)
 
@@ -41,6 +42,8 @@ go build -o qobuz-dl ./cmd/qobuz-dl/
 ./qobuz-dl dl <URL>               # descargar por URL
 ./qobuz-dl lucky -q 6 "Radiohead" # búsqueda + descarga
 ./qobuz-dl fun                     # modo interactivo
+./qobuz-dl csv playlist.csv -q 6  # descarga por lotes desde CSV de TuneMyMusic
+./qobuz-dl csv playlist.csv --failed skipped.csv  # con reporte de fallidos
 ```
 
 ## Pendiente / Ideas
@@ -62,3 +65,24 @@ go build -o qobuz-dl ./cmd/qobuz-dl/
       bar fast-forward a bytes ya descargados via `barCredited`, maneja servidores que ignoran Range
       (responden 200 en vez de 206): trunca y reinicia limpio, cierra `resp.Body` explícitamente
       cada intento para no filtrar conexiones. Helpers: `isContextError`, `isRecoverableErr`.
+- [x] Descarga por lotes desde CSV — `internal/downloader/csvbatch.go`
+      Comando `csv <archivo.csv>` compatible con exportaciones de TuneMyMusic.
+      `ParseCSV`: strip de BOM UTF-8, mapeo dinámico de columnas por nombre, inferencia de
+      artista/título cuando vienen vacíos (split por ` - ` en Track name), FieldsPerRecord=-1.
+      `DownloadCSV`: loop resiliente (nunca fatal), reutiliza `searchFirstTrackID` + `downloadTrackByID`,
+      reporte de resumen al final, flag `--failed <file>` escribe CSV de canciones no encontradas/fallidas.
+
+## Bugs críticos resueltos (v1.3.0)
+
+- **Deadlock en descargas individuales** — `downloadWithProgress` llamaba `mpb.Bar.SetTotal(n, false)`:
+  el `false` impide que mpb marque la barra como completa aunque llegue al 100%, dejando `p.Wait()`
+  bloqueado para siempre. Fix: `SetTotal(n, false)` durante init (solo display), luego
+  `SetTotal(completedAt, true)` explícito DESPUÉS de que `io.Copy` retorna, cuando `ProxyReader`
+  ya no está activo.
+- **Panic (nil pointer dereference en io.Copy) en reintentos** — dos bugs combinados:
+  1. El bloque "server ignored Range" cerraba `resp.Body` y reseteaba estado pero no hacía `continue`,
+     cayendo al resto de la iteración con un body ya cerrado.
+  2. Con `triggerComplete=true` en `SetTotal`, mpb auto-completaba la barra mientras `io.Copy` seguía
+     corriendo; el goroutine `serve` cerraba `operateState`, y el `IncrBy` del probe de EOF enviaba
+     en canal cerrado → panic.
+  Fix: `continue` en el bloque restart + `SetTotal(false)` durante init.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A complete rewrite of [vitiko98/qobuz-dl](https://github.com/vitiko98/qobuz-dl) 
 ## Features
 
 - Download albums, tracks, artists, playlists, and labels by URL
+- **Batch download from a TuneMyMusic CSV export** — `csv` command
 - Quality up to 24-bit / 192kHz Hi-Res
 - FLAC (Vorbis Comment) and MP3 (ID3v2.3) tagging — pure Go, no external tools needed
 - Cover art download and optional embedding
@@ -12,6 +13,7 @@ A complete rewrite of [vitiko98/qobuz-dl](https://github.com/vitiko98/qobuz-dl) 
 - Concurrent track downloads per album
 - Downloads database to skip already-downloaded tracks
 - Configurable folder and track naming formats
+- Last.fm playlist support (loved tracks, recent tracks)
 - OAuth and manual token authentication (password login no longer supported by Qobuz)
 - Minimal dependencies — only stdlib plus a progress-bar library
 
@@ -67,6 +69,7 @@ qobuz-dl [options] <command> [args]
 |---|---|
 | `dl <URL...>` | Download one or more URLs (album, track, artist, label, playlist, Last.fm) |
 | `lucky <query>` | Search and download the top N results |
+| `csv <file.csv>` | Batch download from a TuneMyMusic CSV export |
 | `oauth [code\|url]` | Log in via OAuth |
 | `fun` | Interactive search and download mode |
 
@@ -119,6 +122,36 @@ qobuz > exit                  # quit
 
 After each search, pick result numbers to add to the queue (e.g. `1 3 5`). Type `help` for the full command list.
 
+### CSV batch download (`csv`)
+
+Export your playlist from [TuneMyMusic](https://www.tunemymusic.com/) as CSV, then:
+
+```bash
+# Basic batch download
+./qobuz-dl csv my_playlist.csv
+
+# Hi-res quality + save a report of tracks that failed or weren't found
+./qobuz-dl csv my_playlist.csv -q 27 --failed skipped.csv
+
+# Download to a specific folder
+./qobuz-dl -d ~/Music csv my_playlist.csv -q 6
+```
+
+The parser handles the most common TuneMyMusic export quirk: when `Artist name`, `Album`, and `ISRC` columns are blank and the track appears as `"Artist - Title"` in the `Track name` field, the artist and title are inferred automatically.
+
+At the end of the run a summary is printed:
+
+```
+=== CSV Batch Summary ===
+  Total processed: 50
+  Downloaded:      45
+  Not found:        3
+  Errors:           2
+  Failed tracks saved to: skipped.csv
+```
+
+The `--failed` report is a CSV with columns `row`, `artist`, `title`, `query`, `reason` so you can inspect and retry manually.
+
 ### Last.fm playlists
 
 Pass a Last.fm user playlist URL to `dl` and qobuz-dl will fetch the track list and search each song on Qobuz automatically:
@@ -152,6 +185,7 @@ No Last.fm API key is required. Tracks are saved to `<download-dir>/Last.fm - {u
 | `--smart-discog` | Smart discography filter (skip live/compilation albums) |
 | `--lucky-type` | Item type for `lucky` command: `album`, `track`, `artist`, `playlist` |
 | `--lucky-n` | Number of results to download with `lucky` (default: 1) |
+| `--failed <file>` | Output CSV for failed/not-found tracks after a `csv` run (default: `failed_downloads.csv`) |
 
 ### Quality levels
 

--- a/test_playlist.csv
+++ b/test_playlist.csv
@@ -1,0 +1,5 @@
+﻿Track name,Artist name,Album,Playlist name,Type,ISRC
+"Mon Laferte - Amor Completo","","","Viajes","Playlist",""
+"Imagine Dragons - Bones","","","Viajes","Playlist",""
+"Bandido - Ana Bárbara","","","Viajes","Playlist",""
+"NoExisteEsteTrack - asdasdasd","","","Viajes","Playlist",""


### PR DESCRIPTION
##  Summary

   This release introduces **CSV batch downloading** — compatible with [TuneMyMusic](https://www.tunemymusic.com/) playlist exports — and resolves two critical stability bugs that caused silent hangs and panics on single-track
   downloads in all command modes (`dl`, `lucky`, `fun`).

   ---

   ## New Features

   ### `csv` command — Batch download from a TuneMyMusic CSV export

   ```bash
   ./qobuz-dl csv playlist.csv -d ~/Music -q 27
   ./qobuz-dl csv playlist.csv --failed skipped.csv -q 6
   ```

   - **Smart CSV parsing** (`internal/downloader/csvbatch.go`): Handles the common TuneMyMusic anomaly where `Artist name`, `Album`, and `ISRC` columns are empty and the track appears as `"Artist - Title"` in the `Track name` field.
   The parser infers artist and title via a `" - "` split, then falls back to a full-string query if no separator is found.
   - **UTF-8 BOM stripping**: TuneMyMusic (and many Windows editors) prepend a `\xef\xbb\xbf` BOM that would otherwise corrupt the header column map and silently discard every row. The reader peeks and discards it before parsing.
   - **`--failed <file>` flag**: At the end of the batch run, tracks that were not found on Qobuz or failed to download are written to a structured CSV report (columns: `row`, `artist`, `title`, `query`, `reason`). Defaults to
   `failed_downloads.csv`.
   - **End-of-run summary**: Prints `Total processed / Downloaded / Not found / Errors` after the batch completes.

   ---

   ## 🐛 Critical Bug Fixes

   ### Fix: Silent hang / deadlock after every single-track download

   **Affected commands:** `dl` (single track URL), `lucky`, `fun`, and the new `csv` command.

   **Root cause:** `downloadWithProgress` called `mpb.Bar.SetTotal(n, false)` — the `false` flag tells mpb *"set the denominator for display but never auto-complete this bar"*. After a successful download, the bar reached 100% visually
    but was never marked done in mpb's internal state. `p.Wait()` in `downloadTrackByID` therefore blocked forever.

   **Fix:** `SetTotal` is now called with `triggerComplete=false` during initialisation (display only), and with `triggerComplete=true` **explicitly after `io.Copy` returns** — once the `ProxyReader` goroutine is no longer active.
   `p.Wait()` sees the bar as completed and returns immediately.

   ### Fix: Panic (`nil pointer dereference` in `io.Copy`) on retry after server ignores `Range`

   **Root cause — two compounding issues in `downloadWithProgress`:**

   1. **Missing `continue` in restart path:** When a server responds `200 OK` to a `Range` request (ignoring it and sending the full file), the code closed `resp.Body`, removed the partial file, and reset internal state — but then
   **fell through** and continued using the already-closed body in the same loop iteration. Subsequent use of the closed body caused undefined behavior.

   2. **Bar auto-completion during `io.Copy`:** The previous fix set `SetTotal(n, true)` at the top of the attempt, causing mpb to auto-complete the bar the moment `ProxyReader` fed the last byte — while `io.Copy` was still running and
    about to issue one final `Read` for EOF. mpb's `serve` goroutine closes its `operateState` channel on bar completion; the EOF-probe `IncrBy(0)` sent on the closed channel, producing a `nil pointer dereference` panic.

   **Fix:**
   - Added `continue` to the restart block so a fresh HTTP request is made on the next attempt.
   - Reverted `SetTotal` to `false` during initialisation; completion is now triggered explicitly after `io.Copy` returns cleanly.

   ---

   ## 🛠 Robustness & Graceful Degradation

   - The `csv` batch loop never calls `panic` or `log.Fatal`. Any per-track failure (search error, Qobuz API error, download error, track not found) is caught, logged inline, and the loop advances to the next row.
   - Row-skip warnings are printed to `stderr` when the CSV parser skips a row (malformed line, empty `Track name`), making format issues immediately visible without aborting the run.
   - A missing or unrecognised `Track name` column in the header emits a clear warning listing the actual columns found — prevents silent empty-result runs on unexpected CSV formats.

   ---

   ##  Files Changed

   | File | Change |
   |---|---|
   | `internal/downloader/csvbatch.go` | **New** — CSV parser (`ParseCSV`) + batch download loop (`DownloadCSV`) + failed-report writer |
   | `internal/downloader/downloader.go` | Fix deadlock (`SetTotal` timing), fix panic (restart `continue`), fix panic (explicit post-copy completion) |
   | `cmd/qobuz-dl/main.go` | Add `csv` subcommand, add `--failed` flag, update usage string, bump default version to `v1.3.0` |