### PR TITLE
Add installation methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CMD      := ./cmd/qobuz-dl
 DIST     := dist
 VERSION  ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS  := -s -w -X main.version=$(VERSION)
+UNAME_S := $(shell uname -s)
 
 PLATFORMS := \
 	linux/amd64 \
@@ -11,7 +12,7 @@ PLATFORMS := \
 	darwin/arm64 \
 	windows/amd64
 
-.PHONY: all clean checksums
+.PHONY: all clean checksums install
 
 all: clean $(PLATFORMS) checksums
 
@@ -40,3 +41,11 @@ test:
 
 vet:
 	go vet ./...
+
+install: build
+	@if [ "$(UNAME_S)" = "Darwin" ] || [ "$(UNAME_S)" = "Linux" ]; then \
+		sudo cp $(BINARY) /usr/local/bin/; \
+	else \
+		echo "Please manually copy $(BINARY) to a directory in your PATH"; \
+	fi
+	@echo "Installed $(BINARY) to /usr/local/bin/"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,25 @@ A complete rewrite of [vitiko98/qobuz-dl](https://github.com/vitiko98/qobuz-dl) 
 - Go 1.24+
 - A Qobuz account (subscription required for lossless quality)
 
-## Build
+## Install
+
+```bash
+git clone https://github.com/Aeneaj/qobuz-dl-go.git
+cd qobuz-dl-go
+go install ./cmd/qobuz-dl/
+```
+
+Or if you want install for all users:
+
+```bash
+git clone https://github.com/Aeneaj/qobuz-dl-go.git
+cd qobuz-dl-go
+make install
+```
+
+> Binary will be copied in `/usr/local/bin/`
+
+## Build for manually installation
 
 ```bash
 git clone https://github.com/Aeneaj/qobuz-dl-go.git


### PR DESCRIPTION
After compiling, the user would run the binary using the relative path `./qobuz-dl`.

A new step was added to `Makefile` to install the script in `/usr/local/bin`, making it available to all users from anywhere. The use of this new step is described alongside the native Go installation option `go install ./cmd/qobuz-dl/`