### PR TITLE
fix: re-descargar tracks borrados del disco aunque estén en la DB

### DIFF
--- a/internal/downloader/db.go
+++ b/internal/downloader/db.go
@@ -9,8 +9,9 @@ import (
 )
 
 // downloadDB tracks successfully downloaded track IDs in a plain-text file
-// (one ID per line). It avoids re-downloading when files have been moved or
-// renamed, complementing the path-based check in downloadAndTag.
+// (one ID per line). It complements the on-disk existence check: a track is
+// skipped only when it is recorded here AND its file is still present (see
+// Downloader.alreadyHave), so deleting a file lets it be re-downloaded.
 type downloadDB struct {
 	mu   sync.Mutex
 	path string

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -323,7 +323,7 @@ func (d *Downloader) downloadAlbum(ctx context.Context, albumID, baseDir string)
 	isMP3 := d.Opts.Quality == 5
 
 	p := mpb.NewWithContext(ctx, mpb.WithRefreshRate(150*time.Millisecond))
-	jobs := d.collectTrackJobs(ctx, p, rawItems, albumDir, isMultiDisc)
+	jobs := d.collectTrackJobs(ctx, p, rawItems, albumDir, isMultiDisc, meta, trackFmt, isMP3)
 	d.runTrackJobs(ctx, jobs, meta, isMP3, trackFmt)
 	p.Wait()
 
@@ -385,11 +385,11 @@ func detectMultiDisc(rawItems []interface{}) bool {
 }
 
 // collectTrackJobs is Phase 1 of an album download: it resolves track URLs,
-// filters ineligible items (already in the DB, samples, zero-rate), creates
+// filters ineligible items (already downloaded, samples, zero-rate), creates
 // per-track disc subdirectories on multi-disc albums, and registers a progress
 // bar on p for each surviving track. Tracks whose URL cannot be resolved or
 // whose disc directory cannot be created are reported and skipped.
-func (d *Downloader) collectTrackJobs(ctx context.Context, p *mpb.Progress, rawItems []interface{}, albumDir string, isMultiDisc bool) []trackJob {
+func (d *Downloader) collectTrackJobs(ctx context.Context, p *mpb.Progress, rawItems []interface{}, albumDir string, isMultiDisc bool, albumMeta map[string]interface{}, trackFmt string, isMP3 bool) []trackJob {
 	var jobs []trackJob
 	for idx, t := range rawItems {
 		track, ok := t.(map[string]interface{})
@@ -398,7 +398,15 @@ func (d *Downloader) collectTrackJobs(ctx context.Context, p *mpb.Progress, rawI
 		}
 		trackID := idStr(track["id"])
 
-		if d.db != nil && d.db.has(trackID) {
+		trackDir := albumDir
+		if isMultiDisc {
+			mn := int(track["media_number"].(float64))
+			trackDir = filepath.Join(albumDir, fmt.Sprintf("Disc %d", mn))
+		}
+
+		// Skip only if the track is recorded in the DB AND its file is still on
+		// disk. If the file was deleted, fall through and re-download it.
+		if d.alreadyHave(trackID, finalTrackPath(trackDir, track, albumMeta, trackFmt, isMP3)) {
 			continue
 		}
 
@@ -419,10 +427,7 @@ func (d *Downloader) collectTrackJobs(ctx context.Context, p *mpb.Progress, rawI
 			continue
 		}
 
-		trackDir := albumDir
 		if isMultiDisc {
-			mn := int(track["media_number"].(float64))
-			trackDir = filepath.Join(albumDir, fmt.Sprintf("Disc %d", mn))
 			if err := os.MkdirAll(trackDir, 0755); err != nil {
 				fmt.Printf("\033[31mTrack %s: cannot create disc directory %q: %v. Skipping...\033[0m\n", trackID, trackDir, err)
 				continue
@@ -486,12 +491,6 @@ jobLoop:
 // ---- track download ----
 
 func (d *Downloader) downloadTrackByID(ctx context.Context, trackID, baseDir string) error {
-	// DB check
-	if d.db != nil && d.db.has(trackID) {
-		fmt.Printf("\033[90mTrack %s already in DB, skipping\033[0m\n", trackID)
-		return nil
-	}
-
 	trackURL, err := d.Client.GetTrackURL(ctx, trackID, d.Opts.Quality, "")
 	if err != nil {
 		if d.Opts.QualityFallback {
@@ -545,6 +544,14 @@ func (d *Downloader) downloadTrackByID(ctx context.Context, trackID, baseDir str
 		return fmt.Errorf("create track directory %q: %w", trackDir, err)
 	}
 
+	isMP3 := d.Opts.Quality == 5
+	trackFmt := cleanFormatStr(d.Opts.TrackFormat, fileFormat)
+	// Skip only if recorded in the DB AND still on disk; otherwise re-download.
+	if d.alreadyHave(trackID, finalTrackPath(trackDir, meta, meta, trackFmt, isMP3)) {
+		fmt.Printf("\033[90mTrack %s already downloaded, skipping\033[0m\n", trackID)
+		return nil
+	}
+
 	if !d.Opts.NoCover {
 		if imgURL := nestedStr(meta, "album", "image", "large"); imgURL != "" {
 			if d.Opts.OGCover {
@@ -571,8 +578,6 @@ func (d *Downloader) downloadTrackByID(ctx context.Context, trackID, baseDir str
 		),
 	)
 
-	isMP3 := d.Opts.Quality == 5
-	trackFmt := cleanFormatStr(d.Opts.TrackFormat, fileFormat)
 	if err := d.downloadAndTag(ctx, trackDir, 1, trackURL, meta, meta, true, isMP3, trackFmt, bar); err != nil {
 		bar.Abort(false)
 		p.Wait()
@@ -591,30 +596,15 @@ func (d *Downloader) downloadTrackByID(ctx context.Context, trackID, baseDir str
 
 // ---- core download + tag ----
 
-func (d *Downloader) downloadAndTag(
-	ctx context.Context,
-	dir string,
-	idx int,
-	trackURLDict map[string]interface{},
-	trackMeta map[string]interface{},
-	albumMeta map[string]interface{},
-	isTrack bool,
-	isMP3 bool,
-	trackFmt string,
-	bar *mpb.Bar,
-) error {
-	fileURL, _ := trackURLDict["url"].(string)
-	if fileURL == "" {
-		fmt.Printf("\033[90mTrack not available for download\033[0m\n")
-		return nil
-	}
-
+// finalTrackPath computes the output path for a track, identical to the path
+// downloadAndTag writes to. Centralising it lets callers check whether a track
+// already exists on disk before re-fetching it from the API.
+func finalTrackPath(dir string, trackMeta, albumMeta map[string]interface{}, trackFmt string, isMP3 bool) string {
 	ext := ".flac"
 	if isMP3 {
 		ext = ".mp3"
 	}
 
-	// Build filename from track metadata
 	trackTitle := getTitle(trackMeta)
 	performer := nestedStr(trackMeta, "performer", "name")
 	if performer == "" {
@@ -641,7 +631,40 @@ func (d *Downloader) downloadAndTag(
 	if runes := []rune(finalFile); len(runes) > 250 {
 		finalFile = string(runes[:250])
 	}
-	finalFile += ext
+	return finalFile + ext
+}
+
+// alreadyHave reports whether a track may be skipped: it must be recorded in
+// the downloads DB AND its file must still be present on disk. A track that is
+// in the DB but whose file was deleted (e.g. the user removed the album)
+// returns false so it is re-downloaded instead of silently skipped.
+func (d *Downloader) alreadyHave(trackID, finalFile string) bool {
+	if d.db == nil || !d.db.has(trackID) {
+		return false
+	}
+	_, err := os.Stat(finalFile)
+	return err == nil
+}
+
+func (d *Downloader) downloadAndTag(
+	ctx context.Context,
+	dir string,
+	idx int,
+	trackURLDict map[string]interface{},
+	trackMeta map[string]interface{},
+	albumMeta map[string]interface{},
+	isTrack bool,
+	isMP3 bool,
+	trackFmt string,
+	bar *mpb.Bar,
+) error {
+	fileURL, _ := trackURLDict["url"].(string)
+	if fileURL == "" {
+		fmt.Printf("\033[90mTrack not available for download\033[0m\n")
+		return nil
+	}
+
+	finalFile := finalTrackPath(dir, trackMeta, albumMeta, trackFmt, isMP3)
 
 	if _, err := os.Stat(finalFile); err == nil {
 		if bar != nil {

--- a/internal/downloader/redownload_test.go
+++ b/internal/downloader/redownload_test.go
@@ -1,0 +1,74 @@
+package downloader
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// finalTrackPath must produce the same path downloadAndTag writes to, so the
+// on-disk existence check can find an already-downloaded file.
+func TestFinalTrackPath(t *testing.T) {
+	dir := "/music/album"
+	trackMeta := map[string]interface{}{
+		"track_number": float64(3),
+		"title":        "Song",
+	}
+	albumMeta := map[string]interface{}{
+		"artist": map[string]interface{}{"name": "Artist"},
+	}
+
+	got := finalTrackPath(dir, trackMeta, albumMeta, "{tracknumber} - {tracktitle}", false)
+	want := filepath.Join(dir, "03 - Song") + ".flac"
+	if got != want {
+		t.Errorf("finalTrackPath = %q, want %q", got, want)
+	}
+
+	gotMP3 := finalTrackPath(dir, trackMeta, albumMeta, "{tracknumber} - {tracktitle}", true)
+	if filepath.Ext(gotMP3) != ".mp3" {
+		t.Errorf("finalTrackPath MP3 ext = %q, want .mp3", filepath.Ext(gotMP3))
+	}
+}
+
+// alreadyHave is the heart of the bug fix: a track recorded in the DB must only
+// be skipped when its file is still present on disk. If the user deleted the
+// album, the file is gone and the track must be re-downloaded.
+func TestAlreadyHave(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "present.flac")
+	if err := os.WriteFile(existing, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(dir, "deleted.flac")
+
+	db, err := openDB(filepath.Join(dir, "downloads.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.add("in-db")
+	d := &Downloader{db: db}
+
+	cases := []struct {
+		name      string
+		trackID   string
+		finalFile string
+		want      bool
+	}{
+		{"in DB and on disk -> skip", "in-db", existing, true},
+		{"in DB but deleted -> re-download", "in-db", missing, false},
+		{"not in DB -> download", "not-in-db", existing, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := d.alreadyHave(c.trackID, c.finalFile); got != c.want {
+				t.Errorf("alreadyHave(%q, exists=%v) = %v, want %v", c.trackID, c.finalFile == existing, got, c.want)
+			}
+		})
+	}
+
+	// With no DB, nothing is ever considered already-downloaded.
+	dNoDB := &Downloader{}
+	if dNoDB.alreadyHave("in-db", existing) {
+		t.Error("alreadyHave with nil db should always be false")
+	}
+}


### PR DESCRIPTION
## Problema

Al borrar un álbum del disco y volver a bajarlo, **solo se descargaba el cover art** — ningún track.

## Causa raíz

La downloads DB (`internal/downloader/db.go`) guarda los track IDs de todo lo bajado alguna vez, y vive aparte de la carpeta de música; borrar el álbum no la limpia. En `collectTrackJobs`:

```go
if d.db != nil && d.db.has(trackID) {
    continue   // salta en silencio
}
```

Cada track se saltaba **antes** de mirar el disco, mientras `downloadAlbumExtras` (que no consulta la DB) sí bajaba el `cover.jpg`. Resultado: carpeta recreada con solo el cover. El mismo bug existía en el flujo de track individual (`downloadTrackByID`).

## Fix

El skip por DB ahora exige que el archivo **siga presente en disco**. Si fue borrado, el track se re-descarga (la entrada en la DB se conserva). Cuando el archivo sigue ahí, se mantiene la optimización de saltear sin pegarle a la API.

- **`finalTrackPath`**: extrae el cálculo de ruta de salida desde `downloadAndTag`, para que el chequeo de existencia use *exactamente* la misma ruta que se escribe.
- **`alreadyHave`**: `true` solo si el track está en la DB **y** su archivo existe.
- Aplicado a ambos flujos: álbum (`collectTrackJobs`) y track individual (`downloadTrackByID`).

### Tradeoff (intencional)

Un archivo **movido/renombrado** ya no quedará protegido por la DB: como no está en su ruta esperada, se re-descargará. Se priorizó el caso común y la expectativa del usuario (borrar → recuperar) por sobre la protección de renombrado. `--no-db` y `--purge` siguen disponibles.

## Tests

- `TestFinalTrackPath` — la ruta calculada coincide con la de `downloadAndTag` (FLAC/MP3).
- `TestAlreadyHave` — incluye el caso del bug: en DB pero borrado → re-baja; en DB y presente → saltea; sin DB → nunca saltea.

`go build`, `go vet`, `gofmt -l` y `go test ./internal/downloader/...` en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)