### PR TITLE
feat(downloader): allow subfolders in folder_format and track_format

### DIFF
--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -294,17 +294,22 @@ func (d *Downloader) downloadAlbum(ctx context.Context, albumID, baseDir string)
 	fmt.Printf("\n\033[1m♫  %s\033[0m  ·  \033[33m%s %v/%v\033[0m  ·  %d tracks\n\n",
 		title, fileFormat, bitDepth, samplingRate, trackCount)
 
-	// Build folder name
+	// Build folder name. Individual values are sanitised inside
+	// expandPlaceholders, so literal "/" written in FolderFormat survives as a
+	// subfolder separator (translated to the OS separator by filepath.FromSlash).
 	folderFmt := cleanFormatStr(d.Opts.FolderFormat, fileFormat)
 	folderName := expandPlaceholders(folderFmt, map[string]string{
-		"{artist}":        sanitize(artist),
-		"{album}":         sanitize(title),
+		"{artist}":        artist,
+		"{album}":         title,
 		"{year}":          year,
 		"{bit_depth}":     fmt.Sprintf("%v", bitDepth),
 		"{sampling_rate}": fmt.Sprintf("%v", samplingRate),
 		"{format}":        fileFormat,
 	})
-	albumDir := filepath.Join(baseDir, sanitize(folderName))
+	albumDir, err := safeJoin(baseDir, filepath.FromSlash(folderName))
+	if err != nil {
+		return fmt.Errorf("resolve album directory: %w", err)
+	}
 	if err := os.MkdirAll(albumDir, 0755); err != nil {
 		return fmt.Errorf("create album directory %q: %w", albumDir, err)
 	}
@@ -534,13 +539,16 @@ func (d *Downloader) downloadTrackByID(ctx context.Context, trackID, baseDir str
 
 	folderFmt := cleanFormatStr(d.Opts.FolderFormat, fileFormat)
 	folderName := expandPlaceholders(folderFmt, map[string]string{
-		"{artist}":        sanitize(albumArtist),
-		"{album}":         sanitize(albumTitle),
+		"{artist}":        albumArtist,
+		"{album}":         albumTitle,
 		"{year}":          year,
 		"{bit_depth}":     fmt.Sprintf("%v", int(bitDepth)),
 		"{sampling_rate}": fmt.Sprintf("%v", samplingRate),
 	})
-	trackDir := filepath.Join(baseDir, sanitize(folderName))
+	trackDir, err := safeJoin(baseDir, filepath.FromSlash(folderName))
+	if err != nil {
+		return fmt.Errorf("resolve track directory: %w", err)
+	}
 	if err := os.MkdirAll(trackDir, 0755); err != nil {
 		return fmt.Errorf("create track directory %q: %w", trackDir, err)
 	}
@@ -635,13 +643,24 @@ func (d *Downloader) downloadAndTag(
 		"{version}":       fmt.Sprintf("%v", trackMeta["version"]),
 	}
 	formatted := expandPlaceholders(trackFmt, filenameAttrs)
-	finalFile := filepath.Join(dir, sanitize(formatted))
+	finalFile, err := safeJoin(dir, filepath.FromSlash(formatted))
+	if err != nil {
+		return fmt.Errorf("resolve track path: %w", err)
+	}
 	// Trim to 250 runes to stay within filesystem limits without splitting
 	// multi-byte UTF-8 characters (e.g. CJK, Arabic, emoji in track titles).
 	if runes := []rune(finalFile); len(runes) > 250 {
 		finalFile = string(runes[:250])
 	}
 	finalFile += ext
+
+	// Support subfolder templates in track_format (e.g. "{albumartist}/{album}/...").
+	// safeJoin already guaranteed the parent is inside dir, so MkdirAll is safe.
+	if parent := filepath.Dir(finalFile); parent != dir {
+		if err := os.MkdirAll(parent, 0755); err != nil {
+			return fmt.Errorf("create track parent directory %q: %w", parent, err)
+		}
+	}
 
 	if _, err := os.Stat(finalFile); err == nil {
 		if bar != nil {
@@ -1175,13 +1194,18 @@ func cleanFormatStr(format, fileFormat string) string {
 	return format
 }
 
+// expandPlaceholders substitutes {placeholder} tokens in format with values
+// from attrs. Each value is passed through sanitize so illegal path characters
+// (including "/" and "\") are neutralised before insertion — this lets a
+// format string like "{artist}/{album}" contain real subfolder separators
+// while metadata values (e.g. an artist named "AC/DC") cannot inject them.
 func expandPlaceholders(format string, attrs map[string]string) string {
 	result := format
 	for k, v := range attrs {
 		if v == "" || v == "<nil>" || v == "%!v(MISSING)" {
 			v = "n_a"
 		}
-		result = strings.ReplaceAll(result, k, v)
+		result = strings.ReplaceAll(result, k, sanitize(v))
 	}
 	return result
 }
@@ -1258,6 +1282,19 @@ var reUnsafe = regexp.MustCompile(`[<>:"/\\|?*\x00-\x1f]`)
 func sanitize(s string) string {
 	s = reUnsafe.ReplaceAllString(s, "_")
 	return strings.TrimSpace(s)
+}
+
+// safeJoin joins base with elem, cleans the result, and verifies it still
+// lives under base. Callers must pre-translate user-format separators with
+// filepath.FromSlash so subfolder templates work on Windows. Guards against
+// path traversal from malicious templates or metadata (e.g. "../../etc").
+func safeJoin(base, elem string) (string, error) {
+	cleanBase := filepath.Clean(base)
+	joined := filepath.Clean(filepath.Join(cleanBase, elem))
+	if joined != cleanBase && !strings.HasPrefix(joined, cleanBase+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q escapes base directory %q", elem, cleanBase)
+	}
+	return joined, nil
 }
 
 func nestedStr(m map[string]interface{}, keys ...string) string {

--- a/internal/downloader/helpers_test.go
+++ b/internal/downloader/helpers_test.go
@@ -1,6 +1,11 @@
 package downloader
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 // ---- sanitize -----------------------------------------------------------
 
@@ -66,6 +71,42 @@ func TestExpandPlaceholders(t *testing.T) {
 			attrs:  map[string]string{"{key}": "value"},
 			want:   "literal string",
 		},
+		{
+			// Subfolder support: literal "/" in the template must survive so the
+			// caller can build a directory tree from it.
+			name:   "template slash preserved",
+			format: "{artist}/{album}",
+			attrs:  map[string]string{"{artist}": "Radiohead", "{album}": "OK Computer"},
+			want:   "Radiohead/OK Computer",
+		},
+		{
+			// Adversarial value: a "/" coming from metadata must be neutralised
+			// so it cannot smuggle in an extra path segment.
+			name:   "slash inside value neutralised",
+			format: "{artist}",
+			attrs:  map[string]string{"{artist}": "AC/DC"},
+			want:   "AC_DC",
+		},
+		{
+			// Combined: template separators kept, in-value separators stripped.
+			name:   "subfolder template with dirty value",
+			format: "{artist}/{album}",
+			attrs:  map[string]string{"{artist}": "GZA/Genius", "{album}": "Liquid Swords"},
+			want:   "GZA_Genius/Liquid Swords",
+		},
+		{
+			name:   "backslash inside value neutralised",
+			format: "{title}",
+			attrs:  map[string]string{"{title}": `back\slash`},
+			want:   "back_slash",
+		},
+		{
+			// Colons, quotes, pipes, wildcards, controls — all covered by sanitize.
+			name:   "assorted unsafe chars inside value",
+			format: "{title}",
+			attrs:  map[string]string{"{title}": `a:b"c|d?e*f`},
+			want:   "a_b_c_d_e_f",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -74,6 +115,170 @@ func TestExpandPlaceholders(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ---- safeJoin -----------------------------------------------------------
+
+func TestSafeJoin(t *testing.T) {
+	sep := string(filepath.Separator)
+	base := filepath.Join(sep+"tmp", "base")
+
+	t.Run("success cases", func(t *testing.T) {
+		cases := []struct {
+			name string
+			elem string
+			want string
+		}{
+			{"simple subdir", "sub", filepath.Join(base, "sub")},
+			{"nested subdirs", filepath.Join("a", "b", "c"), filepath.Join(base, "a", "b", "c")},
+			{"dot resolves to base", ".", base},
+			{"empty elem resolves to base", "", base},
+			{"trailing separator normalised", "sub" + sep, filepath.Join(base, "sub")},
+			{"internal double dots that stay inside", filepath.Join("a", "..", "b"), filepath.Join(base, "b")},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				got, err := safeJoin(base, c.elem)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != c.want {
+					t.Errorf("got %q, want %q", got, c.want)
+				}
+			})
+		}
+	})
+
+	t.Run("path traversal is blocked", func(t *testing.T) {
+		attacks := []struct {
+			name string
+			elem string
+		}{
+			{"direct parent escape", filepath.Join("..", "etc")},
+			{"chained parents", filepath.Join("..", "..", "..", "etc", "passwd")},
+			{"indirect via valid subdir", filepath.Join("sub", "..", "..", "etc")},
+			// Prefix trick: joined path shares a prefix with base but is a
+			// sibling directory. HasPrefix(joined, base) alone would miss it —
+			// the trailing separator in the check is what catches it.
+			{"sibling prefix trick", filepath.Join("..", filepath.Base(base)+"_evil")},
+		}
+		for _, a := range attacks {
+			t.Run(a.name, func(t *testing.T) {
+				got, err := safeJoin(base, a.elem)
+				if err == nil {
+					t.Fatalf("expected traversal to be blocked; got %q", got)
+				}
+				if !strings.Contains(err.Error(), "escapes") {
+					t.Errorf("error should mention escape; got: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("absolute-looking elem is treated as relative", func(t *testing.T) {
+		// filepath.Join drops leading separators on subsequent args, so an
+		// elem like "/etc/passwd" is safely re-rooted under base.
+		got, err := safeJoin(base, sep+filepath.Join("etc", "passwd"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := filepath.Join(base, "etc", "passwd")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("base with trailing separator is normalised", func(t *testing.T) {
+		got, err := safeJoin(base+sep, "sub")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := filepath.Join(base, "sub"); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+// ---- folder_format end-to-end (subfolder flow) --------------------------
+
+// TestFolderFormatSubfolder exercises the full pipeline the downloader uses
+// to turn a user format string into a real, safe directory on disk:
+// expandPlaceholders → filepath.FromSlash → safeJoin → MkdirAll.
+func TestFolderFormatSubfolder(t *testing.T) {
+	baseDir := t.TempDir()
+
+	t.Run("template with subfolder creates nested tree", func(t *testing.T) {
+		attrs := map[string]string{
+			"{artist}": "Radiohead",
+			"{album}":  "OK Computer",
+			"{year}":   "1997",
+		}
+		folderName := expandPlaceholders("{artist}/{album} ({year})", attrs)
+		if folderName != "Radiohead/OK Computer (1997)" {
+			t.Fatalf("expandPlaceholders produced %q", folderName)
+		}
+
+		got, err := safeJoin(baseDir, filepath.FromSlash(folderName))
+		if err != nil {
+			t.Fatalf("safeJoin returned error: %v", err)
+		}
+		want := filepath.Join(baseDir, "Radiohead", "OK Computer (1997)")
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+
+		if err := os.MkdirAll(got, 0755); err != nil {
+			t.Fatalf("MkdirAll failed: %v", err)
+		}
+		if info, err := os.Stat(got); err != nil || !info.IsDir() {
+			t.Fatalf("expected directory at %q (err=%v)", got, err)
+		}
+		// The intermediate artist directory must also exist as a real folder,
+		// not flattened into a single name with an underscore.
+		if info, err := os.Stat(filepath.Join(baseDir, "Radiohead")); err != nil || !info.IsDir() {
+			t.Errorf("intermediate artist directory missing — subfolder was flattened")
+		}
+	})
+
+	t.Run("dirty value cannot inject an extra subfolder", func(t *testing.T) {
+		attrs := map[string]string{
+			"{artist}": "GZA/Genius", // legitimate-looking but contains "/"
+			"{album}":  "Liquid Swords",
+		}
+		folderName := expandPlaceholders("{artist}/{album}", attrs)
+		// The "/" from the value must have been replaced with "_" so the
+		// resulting path has exactly two segments, not three.
+		got, err := safeJoin(baseDir, filepath.FromSlash(folderName))
+		if err != nil {
+			t.Fatalf("safeJoin returned error: %v", err)
+		}
+		want := filepath.Join(baseDir, "GZA_Genius", "Liquid Swords")
+		if got != want {
+			t.Fatalf("got %q, want %q — value should have been flattened", got, want)
+		}
+	})
+
+	t.Run("traversal in format string is blocked", func(t *testing.T) {
+		// A malicious admin config with ".." in the folder template.
+		folderName := expandPlaceholders("../{album}", map[string]string{"{album}": "Escape"})
+		if _, err := safeJoin(baseDir, filepath.FromSlash(folderName)); err == nil {
+			t.Fatal("expected traversal to be blocked, got nil")
+		}
+	})
+
+	t.Run("traversal in value is neutralised before reaching safeJoin", func(t *testing.T) {
+		// A dirty value cannot express traversal because sanitize strips "/".
+		// safeJoin therefore accepts it — the result is just an oddly-named
+		// (but contained) folder.
+		folderName := expandPlaceholders("{artist}", map[string]string{"{artist}": "../evil"})
+		got, err := safeJoin(baseDir, filepath.FromSlash(folderName))
+		if err != nil {
+			t.Fatalf("safeJoin should accept the sanitised value: %v", err)
+		}
+		if !strings.HasPrefix(got, baseDir+string(filepath.Separator)) {
+			t.Errorf("resolved path %q escaped base %q", got, baseDir)
+		}
+	})
 }
 
 // ---- renderFormat -------------------------------------------------------


### PR DESCRIPTION
A folder_format like "{artist}/{album}" was flattened into "{artist}_{album}" because sanitize() was applied to the fully expanded string, stripping legitimate path separators.

Invert the sanitization: apply sanitize() per value inside expandPlaceholders so literal "/" written in the template survives as a real subfolder, while metadata values (e.g. an artist named "AC/DC") still cannot inject separators.

Add a safeJoin(base, elem) helper that combines filepath.Clean with a HasPrefix check against base+os.Separator, blocking path traversal from malicious templates (e.g. "../{album}") and defeating the sibling-prefix trick ("../base_evil"). Use filepath.FromSlash so subfolder syntax works on Windows.

Enable subfolder templates in track_format too, by MkdirAll'ing the parent directory when it differs from the album directory.

Tests: 25 new subtests covering
  - expandPlaceholders with subfolder templates and dirty values
  - safeJoin success / traversal / prefix-trick / absolute-elem cases
  - end-to-end folder_format pipeline creating a real nested tree

Closes #7