### PR TITLE
refactor(config): give $XDG_CONFIG_HOME precedence over os.UserConfigDir

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,9 +68,19 @@ type Config struct {
 }
 
 // ConfigDir returns the OS config directory for qobuz-dl.
-// Uses os.UserConfigDir which respects $XDG_CONFIG_HOME on Linux,
-// %AppData% on Windows, and ~/Library/Application Support on macOS.
+//
+// Resolution order:
+//  1. $XDG_CONFIG_HOME, if set to an absolute path. The XDG Base Directory
+//     Spec requires the value to be absolute; relative paths are ignored.
+//     This gives CLI-oriented users the same override on macOS and Windows
+//     that Go's os.UserConfigDir already honours on Linux.
+//  2. os.UserConfigDir — %AppData% on Windows, ~/Library/Application Support
+//     on macOS, and $HOME/.config on Linux (when XDG_CONFIG_HOME is unset).
+//  3. $HOME/.config as a last-resort fallback.
 func ConfigDir() string {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" && filepath.IsAbs(dir) {
+		return filepath.Join(dir, "qobuz-dl")
+	}
 	if dir, err := os.UserConfigDir(); err == nil {
 		return filepath.Join(dir, "qobuz-dl")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -130,6 +130,48 @@ func TestSaveToken(t *testing.T) {
 	}
 }
 
+func TestConfigDir_XDGPrecedence(t *testing.T) {
+	// Isolate HOME so os.UserConfigDir's platform-specific fallback is
+	// deterministic across CI runners.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	t.Run("absolute XDG_CONFIG_HOME takes precedence", func(t *testing.T) {
+		xdg := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", xdg)
+
+		got := ConfigDir()
+		want := filepath.Join(xdg, "qobuz-dl")
+		if got != want {
+			t.Errorf("ConfigDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("relative XDG_CONFIG_HOME is ignored per spec", func(t *testing.T) {
+		// The XDG Base Directory Spec requires absolute paths — a relative
+		// value must be treated as unset. ConfigDir should fall through to
+		// os.UserConfigDir, which under an isolated HOME lives inside homeDir.
+		t.Setenv("XDG_CONFIG_HOME", "relative/path")
+
+		got := ConfigDir()
+		if strings.Contains(got, "relative/path") {
+			t.Fatalf("ConfigDir() honoured a relative XDG value: %q", got)
+		}
+		if !strings.HasPrefix(got, homeDir) {
+			t.Errorf("ConfigDir() = %q, expected fallback under HOME %q", got, homeDir)
+		}
+	})
+
+	t.Run("empty XDG_CONFIG_HOME falls through", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", "")
+
+		got := ConfigDir()
+		if !strings.HasPrefix(got, homeDir) {
+			t.Errorf("ConfigDir() = %q, expected fallback under HOME %q", got, homeDir)
+		}
+	})
+}
+
 func TestWriteINI_StableKeyOrder(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.ini")


### PR DESCRIPTION
Check $XDG_CONFIG_HOME before falling back to os.UserConfigDir so CLI-oriented users get the same override on macOS and Windows that Go's os.UserConfigDir already honours on Linux.

Background: on macOS, os.UserConfigDir returns ~/Library/Application Support and ignores XDG_CONFIG_HOME even when set. That directory is conventionally reserved for GUI apps; most modern CLIs (git, dlv, iTerm2, Zed, ripgrep, bat, delta, ...) respect XDG_CONFIG_HOME per the XDG Base Directory Specification. This aligns qobuz-dl-go with that convention.

Per the XDG spec, only absolute paths are honoured — a relative value is treated as unset and we fall through to os.UserConfigDir. The updated docstring documents the three-step resolution order.

Test: TestConfigDir_XDGPrecedence covers
  - absolute XDG_CONFIG_HOME wins
  - relative XDG_CONFIG_HOME is ignored (spec compliance)
  - empty XDG_CONFIG_HOME falls through to the platform default

Closes #10