### PR TITLE
feat(config): allow setting concurrent workers in config.ini

### DIFF
--- a/cmd/qobuz-dl/main.go
+++ b/cmd/qobuz-dl/main.go
@@ -41,7 +41,7 @@ Options:
   --og-cover         Use original cover quality
   --no-cover         Skip cover art download
   --no-db            Bypass downloads database
-  --workers N        Concurrent track downloads per album (default 3)
+  --workers N        Concurrent track downloads per album (overrides 'workers' in config.ini; default 3)
   --folder-format    Folder naming format string
   --track-format     Track naming format string
   --smart-discog     Smart discography filter
@@ -287,6 +287,11 @@ func initDownloader(ctx context.Context, f *cliFlags) (*downloader.Downloader, e
 	if trackFmt == "" {
 		trackFmt = cfg.TrackFormat
 	}
+	// Workers hierarchy: CLI flag > config > downloader default (applied in New()).
+	workers := f.Workers
+	if workers == 0 {
+		workers = cfg.Workers
+	}
 
 	client := api.New(cfg.AppID, cfg.Secrets)
 
@@ -319,7 +324,7 @@ func initDownloader(ctx context.Context, f *cliFlags) (*downloader.Downloader, e
 		SmartDiscog:     f.SmartDiscog || cfg.SmartDiscog,
 		NoDB:            f.NoDB || cfg.NoDatabase,
 		DBPath:          cfg.DBPath,
-		Workers:         f.Workers,
+		Workers:         workers,
 	}
 	return downloader.New(client, opts)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	FolderFormat   string
 	TrackFormat    string
 	SmartDiscog    bool
+	Workers        int // concurrent track downloads per album (0 = use downloader default)
 	FilePath       string
 	DBPath         string
 }
@@ -144,6 +145,7 @@ func Load() (*Config, error) {
 		FolderFormat:   get("folder_format", DefaultFolder),
 		TrackFormat:    get("track_format", DefaultTrack),
 		SmartDiscog:    getBool("smart_discography"),
+		Workers:        getInt("workers", 0),
 		FilePath:       cfgFile,
 		DBPath:         filepath.Join(dir, "qobuz_dl.db"),
 	}, nil
@@ -164,6 +166,7 @@ func setupPreferences(ctx context.Context, kv map[string]string) error {
 	kv["no_cover"] = "false"
 	kv["no_database"] = "false"
 	kv["smart_discography"] = "false"
+	kv["workers"] = "3"
 	// Kept for backward compat reading old configs; never written by Reset
 	kv["email"] = ""
 	kv["password"] = ""
@@ -320,6 +323,7 @@ func writeINI(path string, kv map[string]string) error {
 		"download_dir", "default_folder", "default_quality", "default_limit",
 		"no_m3u", "albums_only", "no_fallback", "og_cover",
 		"embed_art", "no_cover", "no_database", "smart_discography",
+		"workers",
 		"app_id", "secrets", "private_key",
 		"folder_format", "track_format",
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -172,6 +172,41 @@ func TestConfigDir_XDGPrecedence(t *testing.T) {
 	})
 }
 
+func TestLoad_Workers(t *testing.T) {
+	// Fresh config: 'workers' is written on setup and must round-trip so
+	// the value survives a Load() call. Also verifies missing/absent values
+	// fall back to 0 (letting the downloader apply its own default).
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	cfgDir := filepath.Join(dir, ".config", "qobuz-dl")
+	os.MkdirAll(cfgDir, 0755)
+	cfgFile := filepath.Join(cfgDir, "config.ini")
+
+	cases := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{"explicit value is parsed", "[DEFAULT]\nworkers = 8\n", 8},
+		{"absent key falls back to 0", "[DEFAULT]\nno_m3u = false\n", 0},
+		{"invalid value falls back to 0", "[DEFAULT]\nworkers = abc\n", 0},
+		{"zero is accepted (downloader will default)", "[DEFAULT]\nworkers = 0\n", 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			os.WriteFile(cfgFile, []byte(c.content), 0644)
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.Workers != c.want {
+				t.Errorf("Workers = %d, want %d", cfg.Workers, c.want)
+			}
+		})
+	}
+}
+
 func TestWriteINI_StableKeyOrder(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.ini")


### PR DESCRIPTION
Add a 'workers' key to config.ini so users can persist the concurrent track download count without passing --workers N every time. The CLI flag still wins when provided, matching the resolution order already used for quality, folder_format, and other overlapping settings.

Resolution order (highest → lowest):
  1. --workers N on the command line
  2. workers = N in config.ini
  3. Downloader default (3), applied when the effective value is <= 0

The value is written to a fresh config.ini during setup with the same default (3), so users see the key on inspection and can edit it without needing to know it exists. Invalid or missing values fall through to the default via the existing guard in downloader.New.

Test: TestLoad_Workers covers explicit values, absent keys, invalid values, and the zero-means-default case.

Closes #9