### PR TITLE
refactor: auditoría de sobreingeniería + tests de integración del downloader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ No añadir dependencias nuevas sin discusión. En particular no añadir librerí
 - **Tests rápidos y offline.** Ningún test hace peticiones reales a internet. Servidores mock con `httptest.NewServer`.
 - **Table-driven por defecto.** Slice de `struct{ in, want }` + bucle `for _, c := range cases`. Subtests con `t.Run` cuando hay nombre descriptivo.
 - **Inyección de dependencias por parámetro.** La función pública (`Run`) recibe un cliente real; la interna (`runWithClient`) acepta el cliente como argumento para que los tests pasen uno falso. No usar variables globales para el cliente.
+- **Seams de test como campos, con default de producción.** Cuando algo no se puede inyectar por parámetro (una URL base, un backoff, un destino de salida), va como campo del struct con su valor real puesto en el constructor, y el test lo reescribe. Los que hay: `api.Client.BaseURL`, `lyrics.Client.baseURL/retryDelay/StepDelay`, `Downloader.retryDelay/progressOut`. Sin esto los tests tardarían 15 s en el backoff o llenarían el log de ANSI de las barras.
 - **Helpers de test mínimos.** Los constructores de datos falsos (`fakeFLAC`, `fakeMP3`) viven en `*_test.go`, no en producción.
 
 ### Cobertura por paquete
@@ -65,7 +66,7 @@ No añadir dependencias nuevas sin discusión. En particular no añadir librerí
 | api | 15 | 44% | client_test.go |
 | bundle | 12 | 60% | bundle_test.go |
 | config | 12 | 45% | config_test.go |
-| downloader | 42 | 25% | metadata_test.go, db_test.go, lastfm_test.go, helpers_test.go |
+| downloader | 62 | 51% | metadata_test.go, db_test.go, lastfm_test.go, helpers_test.go, integration_test.go |
 | lyrics | 46 | 74% | metadata_test.go, lrclib_test.go, lyrics_test.go |
 
 Regenerar con `go test -cover ./...`; los números de arriba son de la última
@@ -96,7 +97,7 @@ pasada, no una meta.
 - `go vet ./...` ✅
 - `go fmt ./...` ✅ (CI falla si hay archivos sin formatear)
 - `go test -cover ./...` ✅ (todos los paquetes pasan)
-- Cobertura: api 44%, bundle 60%, config 45%, downloader 25%, lyrics 74% (135 tests, incluidos 8 de subproceso en cmd/)
+- Cobertura: api 44%, bundle 60%, config 45%, downloader 51%, lyrics 74% (155 tests, incluidos 8 de subproceso en cmd/)
 
 ## Comandos de construcción
 
@@ -215,7 +216,14 @@ lyrics_test.go    — buildLabel (formato, ancho fijo, truncado), lrcPathFor, sc
 - [x] Downloads DB (archivo plano, un track ID por línea) — `internal/downloader/db.go`
       `--no-db` bypass; `--purge` borra el archivo; se carga al arrancar en un map[string]struct{}
 - [x] Descargas concurrentes por track — semáforo + WaitGroup, flag `--workers N` (default 3)
-- [ ] Tests de integración con servidor mock completo para downloader
+- [x] Tests de integración con servidor mock completo para downloader —
+      `internal/downloader/integration_test.go`. Dos mocks `httptest`: `flakyCDN`
+      (servidor de ficheros que corta la conexión a mitad, ignora `Range` o
+      devuelve 4xx, para exprimir el reintento/resume) y `qobuzMock` (API +
+      CDN: `album/get`, `track/get`, `track/getFileUrl`, `artist/get`,
+      `playlist/get`, audio y carátula). El audio servido es un FLAC mínimo
+      real, así que el tagging de producción se ejecuta y se verifica leyendo
+      los tags del fichero final.
 - [x] Soporte last.fm playlists — `internal/downloader/lastfm.go`
       XSPF API 1.0 (sin API key); soporta `/user/{user}/loved` y `/user/{user}/library`;
       busca cada track en Qobuz y descarga el primer resultado

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,12 +154,12 @@ Jerarquía de prioridad al resolver la ruta de descarga:
 3. Fallback: `./qobuz-downloader` (relativo al CWD)
 
 Implementación:
-- `config.ResolveDir(dir string) (string, error)` — expande `~`, llama `filepath.Abs`, crea con `os.MkdirAll`; devuelve error descriptivo si hay problema de permisos (sin panic)
+- `config.ResolveDir(dir string, create bool) (string, error)` — expande `~`, llama `filepath.Abs`; devuelve error descriptivo si hay problema de permisos (sin panic)
 - `Config.DownloadDir` — campo separado de `DefaultFolder` (que es el formato de nombre de álbum, no una ruta)
 - `Reset()` pregunta al usuario por el directorio antes de `default_folder`
 - `downloader.New()` ya no tiene fallback hardcodeado — la ruta llega siempre resuelta desde `initDownloader`
 
-**Importante**: el comando `lyrics` usa `resolveScanDir` (en `lyrics_cmd.go`), que es igual a `ResolveDir` pero **sin** `os.MkdirAll` — no crea el directorio si no existe. El usuario debe apuntar a una biblioteca ya existente.
+**Importante**: el flag `create` distingue los dos usos. Los comandos de descarga llaman `ResolveDir(dir, true)` y crean el árbol con `os.MkdirAll`. El comando `lyrics` llama `ResolveDir(dir, false)`, que exige que el directorio ya exista y sea un directorio — nunca lo crea. El usuario debe apuntar a una biblioteca ya existente.
 
 ## Comando `lyrics` — detalles de implementación
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ No añadir dependencias nuevas sin discusión. En particular no añadir librerí
 - **Tests rápidos y offline.** Ningún test hace peticiones reales a internet. Servidores mock con `httptest.NewServer`.
 - **Table-driven por defecto.** Slice de `struct{ in, want }` + bucle `for _, c := range cases`. Subtests con `t.Run` cuando hay nombre descriptivo.
 - **Inyección de dependencias por parámetro.** La función pública (`Run`) recibe un cliente real; la interna (`runWithClient`) acepta el cliente como argumento para que los tests pasen uno falso. No usar variables globales para el cliente.
-- **Seams de test como campos, con default de producción.** Cuando algo no se puede inyectar por parámetro (una URL base, un backoff, un destino de salida), va como campo del struct con su valor real puesto en el constructor, y el test lo reescribe. Los que hay: `api.Client.BaseURL`, `lyrics.Client.baseURL/retryDelay/StepDelay`, `Downloader.retryDelay/progressOut`. Sin esto los tests tardarían 15 s en el backoff o llenarían el log de ANSI de las barras.
+- **Seams de test como campos, con default de producción.** Cuando algo no se puede inyectar por parámetro (una URL base, un backoff, un destino de salida), va como campo del struct con su valor real puesto en el constructor, y el test lo reescribe. Los que hay: `api.Client.BaseURL`, `lyrics.Client.baseURL/retryDelay/StepDelay`, `Downloader.retryDelay/progressOut/lastfmBase`. Sin esto los tests tardarían 15 s en el backoff o llenarían el log de ANSI de las barras.
 - **Helpers de test mínimos.** Los constructores de datos falsos (`fakeFLAC`, `fakeMP3`) viven en `*_test.go`, no en producción.
 
 ### Cobertura por paquete
@@ -66,7 +66,7 @@ No añadir dependencias nuevas sin discusión. En particular no añadir librerí
 | api | 15 | 44% | client_test.go |
 | bundle | 12 | 60% | bundle_test.go |
 | config | 12 | 45% | config_test.go |
-| downloader | 62 | 51% | metadata_test.go, db_test.go, lastfm_test.go, helpers_test.go, integration_test.go |
+| downloader | 73 | 60% | metadata_test.go, db_test.go, lastfm_test.go, helpers_test.go, integration_test.go |
 | lyrics | 46 | 74% | metadata_test.go, lrclib_test.go, lyrics_test.go |
 
 Regenerar con `go test -cover ./...`; los números de arriba son de la última
@@ -97,7 +97,7 @@ pasada, no una meta.
 - `go vet ./...` ✅
 - `go fmt ./...` ✅ (CI falla si hay archivos sin formatear)
 - `go test -cover ./...` ✅ (todos los paquetes pasan)
-- Cobertura: api 44%, bundle 60%, config 45%, downloader 51%, lyrics 74% (155 tests, incluidos 8 de subproceso en cmd/)
+- Cobertura: api 44%, bundle 60%, config 45%, downloader 60%, lyrics 74% (166 tests, incluidos 8 de subproceso en cmd/)
 
 ## Comandos de construcción
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,13 +39,12 @@ Cualquier nueva feature con feedback visual debe reutilizar este patrón para co
 
 ## Dependencias externas
 
-Las dependencias de módulo son:
+Hay **una sola** dependencia directa:
 - `github.com/vbauerster/mpb/v8` — barras de progreso
-- `github.com/acarl005/stripansi` — limpieza de secuencias ANSI
-- `github.com/VividCortex/ewma` — media móvil (usada por mpb)
-- `github.com/mattn/go-runewidth` — ancho de caracteres Unicode
-- `github.com/clipperhouse/uax29/v2` — segmentación de texto Unicode
-- `golang.org/x/sys` — syscalls de bajo nivel
+
+Las demás son transitivas de mpb (marcadas `// indirect` en `go.mod`) y no se
+importan desde este código: `acarl005/stripansi`, `VividCortex/ewma`,
+`mattn/go-runewidth`, `clipperhouse/uax29/v2`, `golang.org/x/sys`.
 
 No añadir dependencias nuevas sin discusión. En particular no añadir librerías de parseo de audio (dhowden/tag, mewkiz/flac, bogem/id3v2, etc.) — ya tenemos implementaciones propias.
 
@@ -63,13 +62,16 @@ No añadir dependencias nuevas sin discusión. En particular no añadir librerí
 
 | Paquete | Tests | Cobertura | Archivos de test |
 |---|---|---|---|
-| api | — | ~42% | api_test.go |
-| bundle | — | ~64% | bundle_test.go |
-| config | — | ~46% | config_test.go |
-| downloader | 30+ | ~35% | metadata_test.go, db_test.go, lastfm_test.go, helpers_test.go |
-| lyrics | 42 | ~100% | metadata_test.go, lrclib_test.go, lyrics_test.go |
+| api | 15 | 44% | client_test.go |
+| bundle | 12 | 60% | bundle_test.go |
+| config | 12 | 45% | config_test.go |
+| downloader | 42 | 25% | metadata_test.go, db_test.go, lastfm_test.go, helpers_test.go |
+| lyrics | 46 | 74% | metadata_test.go, lrclib_test.go, lyrics_test.go |
 
-`helpers_test.go` en downloader cubre: `sanitize`, `expandPlaceholders`, `renderFormat`, `formatDuration`, `idStr`, `nestedStr`, `releaseYear`, `essenceTitle`, `isAlbumType`.
+Regenerar con `go test -cover ./...`; los números de arriba son de la última
+pasada, no una meta.
+
+`helpers_test.go` en downloader cubre: `sanitize`, `expandPlaceholders`, `renderFormat`, `formatDuration`, `idStr`, `nestedStr`, `releaseYear`, `essenceTitle`, `isRemaster`.
 
 ### CI (`.github/workflows/ci.yml`)
 
@@ -94,7 +96,7 @@ No añadir dependencias nuevas sin discusión. En particular no añadir librerí
 - `go vet ./...` ✅
 - `go fmt ./...` ✅ (CI falla si hay archivos sin formatear)
 - `go test -cover ./...` ✅ (todos los paquetes pasan)
-- Cobertura: api 42%, bundle 64%, config 46%, downloader ~35% (30+ tests), lyrics 100% (42 tests)
+- Cobertura: api 44%, bundle 60%, config 45%, downloader 25%, lyrics 74% (135 tests, incluidos 8 de subproceso en cmd/)
 
 ## Comandos de construcción
 
@@ -155,8 +157,8 @@ Jerarquía de prioridad al resolver la ruta de descarga:
 
 Implementación:
 - `config.ResolveDir(dir string, create bool) (string, error)` — expande `~`, llama `filepath.Abs`; devuelve error descriptivo si hay problema de permisos (sin panic)
-- `Config.DownloadDir` — campo separado de `DefaultFolder` (que es el formato de nombre de álbum, no una ruta)
-- `Reset()` pregunta al usuario por el directorio antes de `default_folder`
+- `Config.DownloadDir` — la ruta base. El formato del nombre de carpeta de cada álbum es `folder_format`, cosa distinta
+- `Reset()` pregunta al usuario por el directorio antes que por la calidad
 - `downloader.New()` ya no tiene fallback hardcodeado — la ruta llega siempre resuelta desde `initDownloader`
 
 **Importante**: el flag `create` distingue los dos usos. Los comandos de descarga llaman `ResolveDir(dir, true)` y crean el árbol con `os.MkdirAll`. El comando `lyrics` llama `ResolveDir(dir, false)`, que exige que el directorio ya exista y sea un directorio — nunca lo crea. El usuario debe apuntar a una biblioteca ya existente.

--- a/cmd/qobuz-dl/lyrics_cmd.go
+++ b/cmd/qobuz-dl/lyrics_cmd.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/Aeneaj/qobuz-dl-go/internal/config"
 	"github.com/Aeneaj/qobuz-dl-go/internal/lyrics"
@@ -45,7 +42,8 @@ Options:
 		scanDir = "./qobuz-downloader"
 	}
 
-	resolved, err := resolveScanDir(scanDir)
+	// The library must already exist — never create it.
+	resolved, err := config.ResolveDir(scanDir, false)
 	if err != nil {
 		fatalf("lyrics: %v", err)
 	}
@@ -53,27 +51,4 @@ Options:
 	if err := lyrics.Run(ctx, resolved); err != nil {
 		fatalf("lyrics: %v", err)
 	}
-}
-
-// resolveScanDir expands ~ and returns an absolute path.
-// Unlike config.ResolveDir it does NOT create the directory — the user must
-// point lyrics at an existing music library.
-func resolveScanDir(dir string) (string, error) {
-	if strings.HasPrefix(dir, "~/") || dir == "~" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("expand ~: %w", err)
-		}
-		dir = filepath.Join(home, dir[1:])
-	}
-	abs, err := filepath.Abs(dir)
-	if err != nil {
-		return "", fmt.Errorf("resolve path %q: %w", dir, err)
-	}
-	if info, err := os.Stat(abs); err != nil {
-		return "", fmt.Errorf("directory not found: %q", abs)
-	} else if !info.IsDir() {
-		return "", fmt.Errorf("%q is not a directory", abs)
-	}
-	return abs, nil
 }

--- a/cmd/qobuz-dl/main.go
+++ b/cmd/qobuz-dl/main.go
@@ -54,14 +54,17 @@ func main() {
 	fs := flag.NewFlagSet("qobuz-dl", flag.ExitOnError)
 	fs.Usage = func() { fmt.Print(usage) }
 
-	reset := fs.Bool("r", false, "")
-	resetLong := fs.Bool("reset", false, "")
-	showCfg := fs.Bool("s", false, "")
-	showCfgLong := fs.Bool("show-config", false, "")
-	purge := fs.Bool("p", false, "")
-	purgeLong := fs.Bool("purge", false, "")
-	showVer := fs.Bool("v", false, "")
-	showVerLong := fs.Bool("version", false, "")
+	// Short and long spelling of each option share one variable, so either
+	// form sets it.
+	var reset, showCfg, purge, showVer bool
+	fs.BoolVar(&reset, "r", false, "")
+	fs.BoolVar(&reset, "reset", false, "")
+	fs.BoolVar(&showCfg, "s", false, "")
+	fs.BoolVar(&showCfg, "show-config", false, "")
+	fs.BoolVar(&purge, "p", false, "")
+	fs.BoolVar(&purge, "purge", false, "")
+	fs.BoolVar(&showVer, "v", false, "")
+	fs.BoolVar(&showVer, "version", false, "")
 
 	flags := registerDownloadFlags(fs)
 	luckyType := fs.String("lucky-type", "album", "")
@@ -70,11 +73,7 @@ func main() {
 
 	fs.Parse(os.Args[1:])
 
-	doReset := *reset || *resetLong
-	doShow := *showCfg || *showCfgLong
-	doPurge := *purge || *purgeLong
-
-	if *showVer || *showVerLong {
+	if showVer {
 		fmt.Println("qobuz-dl", version)
 		return
 	}
@@ -94,7 +93,7 @@ func main() {
 		os.Exit(1)
 	}()
 
-	if doReset {
+	if reset {
 		if err := config.Reset(ctx); err != nil {
 			fmt.Fprintf(os.Stderr, "\033[31mError: %v\n", err)
 			os.Exit(1)
@@ -102,7 +101,7 @@ func main() {
 		return
 	}
 
-	if doShow {
+	if showCfg {
 		cfgFile := config.ConfigDir() + "/config.ini"
 		fmt.Printf("Configuration: %s\n---\n", cfgFile)
 		data, _ := os.ReadFile(cfgFile)
@@ -110,7 +109,7 @@ func main() {
 		return
 	}
 
-	if doPurge {
+	if purge {
 		dbPath := config.ConfigDir() + "/qobuz_dl.db"
 		os.Remove(dbPath)
 		fmt.Println("\033[32mThe database was deleted.\033[0m")

--- a/cmd/qobuz-dl/main.go
+++ b/cmd/qobuz-dl/main.go
@@ -158,7 +158,7 @@ func main() {
 			fatalf("%v", err)
 		}
 		fmt.Printf("\033[33mSearching %ss for \"%s\" (top %d)...\033[0m\n", *luckyType, query, *luckyN)
-		urls, err := searchByType(ctx, dl.Client, *luckyType, query, *luckyN)
+		urls, err := downloader.SearchURLs(ctx, dl.Client, *luckyType, query, *luckyN)
 		if err != nil {
 			fatalf("%v", err)
 		}
@@ -301,8 +301,7 @@ func initDownloader(ctx context.Context, f *cliFlags) (*downloader.Downloader, e
 		return nil, err
 	}
 
-	qualityNames := map[int]string{5: "5 - MP3", 6: "6 - 16 bit, 44.1kHz", 7: "7 - 24 bit, <96kHz", 27: "27 - 24 bit, >96kHz"}
-	fmt.Printf("\033[33mSet max quality: %s\033[0m\n", qualityNames[quality])
+	fmt.Printf("\033[33mSet max quality: %s\033[0m\n", downloader.Qualities[quality])
 
 	opts := downloader.Options{
 		Directory:       dir,
@@ -321,8 +320,4 @@ func initDownloader(ctx context.Context, f *cliFlags) (*downloader.Downloader, e
 		Workers:         f.Workers,
 	}
 	return downloader.New(client, opts)
-}
-
-func searchByType(ctx context.Context, client *api.Client, itemType, query string, limit int) ([]string, error) {
-	return downloader.SearchURLs(ctx, client, itemType, query, limit)
 }

--- a/cmd/qobuz-dl/main.go
+++ b/cmd/qobuz-dl/main.go
@@ -269,7 +269,7 @@ func initDownloader(ctx context.Context, f *cliFlags) (*downloader.Downloader, e
 	if dir == "" {
 		dir = "./qobuz-downloader"
 	}
-	resolvedDir, err := config.ResolveDir(dir)
+	resolvedDir, err := config.ResolveDir(dir, true)
 	if err != nil {
 		return nil, fmt.Errorf("download directory: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,12 @@ module github.com/Aeneaj/qobuz-dl-go
 
 go 1.24.0
 
+require github.com/vbauerster/mpb/v8 v8.12.0
+
 require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect
-	github.com/vbauerster/mpb/v8 v8.12.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 )

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -91,7 +91,7 @@ func (c *Client) doRequest(ctx context.Context, method, endpoint string, params 
 		case 400:
 			return nil, &InvalidAppIDError{"Invalid app id. " + resetMsg}
 		}
-	} else if (endpoint == "track/getFileUrl" || endpoint == "favorite/getUserFavorites") && resp.StatusCode == 400 {
+	} else if endpoint == "track/getFileUrl" && resp.StatusCode == 400 {
 		return nil, &InvalidAppSecretError{fmt.Sprintf("Invalid app secret: %s. %s", string(respBody), resetMsg)}
 	}
 
@@ -311,22 +311,6 @@ func (c *Client) GetTrackURL(ctx context.Context, trackID string, fmtID int, sec
 		"track_id":    {trackID},
 		"format_id":   {strconv.Itoa(fmtID)},
 		"intent":      {"stream"},
-	})
-}
-
-// GetFavoriteAlbums returns the user's favorite albums.
-func (c *Client) GetFavoriteAlbums(ctx context.Context, offset, limit int) (map[string]interface{}, error) {
-	unix := strconv.FormatInt(time.Now().Unix(), 10)
-	rawSig := "favoritegetUserFavorites" + unix + c.Secret
-	sig := md5hex(rawSig)
-	return c.doGet(ctx, "favorite/getUserFavorites", url.Values{
-		"app_id":          {c.AppID},
-		"user_auth_token": {c.UAT},
-		"type":            {"albums"},
-		"request_ts":      {unix},
-		"request_sig":     {sig},
-		"limit":           {strconv.Itoa(limit)},
-		"offset":          {strconv.Itoa(offset)},
 	})
 }
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -30,6 +30,7 @@ type Client struct {
 	UserID  string
 	Label   string // subscription tier
 	Secret  string // validated app secret
+	BaseURL string // API root; tests point this at a mock server
 	http    *http.Client
 }
 
@@ -38,6 +39,7 @@ func New(appID string, secrets []string) *Client {
 	return &Client{
 		AppID:   appID,
 		Secrets: secrets,
+		BaseURL: baseURL,
 		http:    &http.Client{Timeout: 30 * time.Second},
 	}
 }
@@ -51,7 +53,11 @@ func (c *Client) doPost(ctx context.Context, endpoint, body string) (map[string]
 }
 
 func (c *Client) doRequest(ctx context.Context, method, endpoint string, params url.Values, body string) (map[string]interface{}, error) {
-	fullURL := baseURL + endpoint
+	root := c.BaseURL
+	if root == "" {
+		root = baseURL
+	}
+	fullURL := root + endpoint
 	var reqBody io.Reader
 	if body != "" {
 		reqBody = strings.NewReader(body)

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -5,23 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
-	"strings"
 	"testing"
 )
-
-func mockServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *Client) {
-	t.Helper()
-	srv := httptest.NewServer(handler)
-	c := &Client{
-		AppID:   "123456789",
-		Secrets: []string{"testsecret"},
-		http:    srv.Client(),
-	}
-	// Point baseURL at mock — we override via the transport
-	// Instead, use a wrapper that redirects calls
-	return srv, c
-}
 
 func TestMD5Hex(t *testing.T) {
 	tests := []struct{ in, want string }{
@@ -138,21 +123,14 @@ func TestDoGet_401_ReturnsAuthError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := &Client{AppID: "123", http: srv.Client()}
-	// Temporarily repoint base
-	origBase := baseURL
-	_ = origBase // read to satisfy linter if baseURL were a var; it's a const so we use a shim
-
-	// We test via AuthWithPassword which calls user/login
-	// Since baseURL is const, we test the error type from a manual HTTP call
-	resp, err := srv.Client().Get(srv.URL + "/user/login")
-	if err != nil {
-		t.Fatal(err)
+	c := clientForServer(t, srv)
+	err := c.AuthWithToken(context.Background(), "1", "badtoken")
+	if err == nil {
+		t.Fatal("expected an error for HTTP 401")
 	}
-	if resp.StatusCode != 401 {
-		t.Errorf("mock returned %d, want 401", resp.StatusCode)
+	if _, ok := err.(*AuthenticationError); !ok {
+		t.Errorf("expected *AuthenticationError, got %T: %v", err, err)
 	}
-	_ = c
 }
 
 func TestErrorTypes(t *testing.T) {
@@ -380,37 +358,10 @@ func TestHTTP500_ReturnsError(t *testing.T) {
 // clientForServer creates a Client whose HTTP calls go to the given test server.
 func clientForServer(t *testing.T, srv *httptest.Server) *Client {
 	t.Helper()
-	c := &Client{
+	return &Client{
 		AppID:   "123456789",
 		Secrets: []string{"testsecret"},
+		BaseURL: srv.URL + "/api.json/0.2/",
 		http:    srv.Client(),
 	}
-	// Monkey-patch baseURL by wrapping the transport to rewrite URLs
-	origTransport := srv.Client().Transport
-	srv.Client().Transport = &rewriteTransport{
-		base:    baseURL,
-		target:  srv.URL + "/api.json/0.2/",
-		wrapped: origTransport,
-	}
-	return c
-}
-
-type rewriteTransport struct {
-	base, target string
-	wrapped      http.RoundTripper
-}
-
-func (r *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if r.wrapped == nil {
-		r.wrapped = http.DefaultTransport
-	}
-	// Replace baseURL prefix with test server URL
-	newURL := strings.Replace(req.URL.String(), r.base, r.target, 1)
-	newReq := req.Clone(req.Context())
-	parsed, err := url.Parse(newURL)
-	if err != nil {
-		return nil, err
-	}
-	newReq.URL = parsed
-	return r.wrapped.RoundTrip(newReq)
 }

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -162,7 +162,6 @@ func TestErrorTypes(t *testing.T) {
 		&InvalidAppIDError{"test"},
 		&InvalidAppSecretError{"test"},
 		&InvalidQualityError{"test"},
-		&NonStreamableError{"test"},
 	}
 	for _, err := range errs {
 		if err.Error() == "" {

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -7,11 +7,9 @@ type IneligibleError struct{ msg string }
 type InvalidAppIDError struct{ msg string }
 type InvalidAppSecretError struct{ msg string }
 type InvalidQualityError struct{ msg string }
-type NonStreamableError struct{ msg string }
 
 func (e *AuthenticationError) Error() string   { return fmt.Sprintf("authentication error: %s", e.msg) }
 func (e *IneligibleError) Error() string       { return fmt.Sprintf("ineligible: %s", e.msg) }
 func (e *InvalidAppIDError) Error() string     { return fmt.Sprintf("invalid app id: %s", e.msg) }
 func (e *InvalidAppSecretError) Error() string { return fmt.Sprintf("invalid app secret: %s", e.msg) }
 func (e *InvalidQualityError) Error() string   { return fmt.Sprintf("invalid quality: %s", e.msg) }
-func (e *NonStreamableError) Error() string    { return fmt.Sprintf("non streamable: %s", e.msg) }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,9 +14,11 @@ import (
 	"github.com/Aeneaj/qobuz-dl-go/internal/bundle"
 )
 
-// ResolveDir expands ~ and relative paths, then creates the directory tree.
-// Returns the absolute path ready to use, or an error if creation fails.
-func ResolveDir(dir string) (string, error) {
+// ResolveDir expands ~ and relative paths and returns the absolute path.
+// With create set the directory tree is created (download targets); without
+// it the directory must already exist, which is what scanning an existing
+// music library needs.
+func ResolveDir(dir string, create bool) (string, error) {
 	if dir == "" {
 		return "", fmt.Errorf("directory path is empty")
 	}
@@ -31,8 +33,18 @@ func ResolveDir(dir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve path %q: %w", dir, err)
 	}
-	if err := os.MkdirAll(abs, 0755); err != nil {
-		return "", fmt.Errorf("create directory %q: %w", abs, err)
+	if create {
+		if err := os.MkdirAll(abs, 0755); err != nil {
+			return "", fmt.Errorf("create directory %q: %w", abs, err)
+		}
+		return abs, nil
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", fmt.Errorf("directory not found: %q", abs)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%q is not a directory", abs)
 	}
 	return abs, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,9 +59,7 @@ type Config struct {
 	UserID         string
 	UserAuthToken  string
 	DownloadDir    string
-	DefaultFolder  string
 	DefaultQuality int
-	DefaultLimit   int
 	NoM3U          bool
 	AlbumsOnly     bool
 	NoFallback     bool
@@ -130,9 +128,7 @@ func Load() (*Config, error) {
 		UserID:         get("user_id", ""),
 		UserAuthToken:  get("user_auth_token", ""),
 		DownloadDir:    get("download_dir", ""),
-		DefaultFolder:  get("default_folder", "Qobuz Downloads"),
 		DefaultQuality: getInt("default_quality", 6),
-		DefaultLimit:   getInt("default_limit", 20),
 		NoM3U:          getBool("no_m3u"),
 		AlbumsOnly:     getBool("albums_only"),
 		NoFallback:     getBool("no_fallback"),
@@ -155,9 +151,7 @@ func Load() (*Config, error) {
 // Shared by Reset and InitConfig. ctx cancels the bundle.Fetch HTTP calls.
 func setupPreferences(ctx context.Context, kv map[string]string) error {
 	kv["download_dir"] = prompt("Enter default download directory (leave blank for ./qobuz-downloader):\n- ")
-	kv["default_folder"] = promptDefault("Folder for downloads (leave empty for 'Qobuz Downloads')\n- ", "Qobuz Downloads")
 	kv["default_quality"] = promptDefault("Download quality (5, 6, 7, 27) [320, LOSSLESS, 24B <96KHZ, 24B >96KHZ]\n(leave empty for '6')\n- ", "6")
-	kv["default_limit"] = "20"
 	kv["no_m3u"] = "false"
 	kv["albums_only"] = "false"
 	kv["no_fallback"] = "false"
@@ -166,9 +160,6 @@ func setupPreferences(ctx context.Context, kv map[string]string) error {
 	kv["no_cover"] = "false"
 	kv["no_database"] = "false"
 	kv["smart_discography"] = "false"
-	// Kept for backward compat reading old configs; never written by Reset
-	kv["email"] = ""
-	kv["password"] = ""
 	kv["folder_format"] = DefaultFolder
 	kv["track_format"] = DefaultTrack
 
@@ -316,10 +307,11 @@ func readINI(path string) (map[string]string, error) {
 }
 
 func writeINI(path string, kv map[string]string) error {
+	// Keys not listed here (including those of retired settings found in an
+	// existing config) are appended afterwards rather than dropped.
 	order := []string{
 		"user_id", "user_auth_token",
-		"email", "password", // legacy — kept for reading old configs
-		"download_dir", "default_folder", "default_quality", "default_limit",
+		"download_dir", "default_quality",
 		"no_m3u", "albums_only", "no_fallback", "og_cover",
 		"embed_art", "no_cover", "no_database", "smart_discography",
 		"app_id", "secrets", "private_key",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,58 @@ import (
 	"testing"
 )
 
+func TestResolveDir(t *testing.T) {
+	base := t.TempDir()
+	existing := filepath.Join(base, "library")
+	if err := os.Mkdir(existing, 0755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(base, "not-a-dir.txt")
+	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	absent := filepath.Join(base, "absent")
+
+	cases := []struct {
+		name    string
+		dir     string
+		create  bool
+		wantErr bool
+	}{
+		{"creates missing tree", filepath.Join(base, "new", "nested"), true, false},
+		{"accepts existing dir", existing, false, false},
+		{"rejects missing dir", absent, false, true},
+		{"rejects plain file", file, false, true},
+		{"rejects empty path", "", true, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ResolveDir(c.dir, c.create)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveDir: %v", err)
+			}
+			if !filepath.IsAbs(got) {
+				t.Errorf("path %q is not absolute", got)
+			}
+			if info, statErr := os.Stat(got); statErr != nil || !info.IsDir() {
+				t.Errorf("%q is not an existing directory", got)
+			}
+		})
+	}
+
+	// The whole point of create=false: scanning must never create the library.
+	if _, err := os.Stat(absent); !os.IsNotExist(err) {
+		t.Errorf("ResolveDir(create=false) created %q", absent)
+	}
+}
+
 func TestWriteReadINI_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.ini")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -186,19 +186,23 @@ func TestWriteINI_StableKeyOrder(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.ini")
 	kv := map[string]string{
-		"email":    "a@b.com",
-		"password": "hash",
+		"user_id":  "42",
+		"no_m3u":   "false",
 		"app_id":   "123",
 		"secrets":  "s1,s2",
+		"obsolete": "leftover",
 	}
 	writeINI(path, kv)
 
 	data, _ := os.ReadFile(path)
 	content := string(data)
-	// email should appear before app_id (per ordered list)
-	emailPos := strings.Index(content, "email")
-	appIDPos := strings.Index(content, "app_id")
-	if emailPos > appIDPos {
-		t.Errorf("expected email before app_id in output")
+	// user_id, then no_m3u, then app_id — per the ordered list.
+	if strings.Index(content, "user_id") > strings.Index(content, "no_m3u") ||
+		strings.Index(content, "no_m3u") > strings.Index(content, "app_id") {
+		t.Errorf("keys out of order:\n%s", content)
+	}
+	// Unlisted keys are kept, not dropped.
+	if !strings.Contains(content, "obsolete = leftover") {
+		t.Errorf("unlisted key was dropped:\n%s", content)
 	}
 }

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -30,7 +30,8 @@ const (
 	bookletFile = "booklet.pdf"
 )
 
-var qualities = map[int]string{
+// Qualities maps a Qobuz format id to its human-readable name.
+var Qualities = map[int]string{
 	5:  "5 - MP3",
 	6:  "6 - 16 bit, 44.1kHz",
 	7:  "7 - 24 bit, <96kHz",
@@ -646,7 +647,7 @@ func (d *Downloader) fallbackQuality(ctx context.Context, trackID string) (map[s
 		}
 		info, err := d.Client.GetTrackURL(ctx, trackID, q, "")
 		if err == nil {
-			fmt.Printf("\033[33mQuality fallback to %s for track %s\033[0m\n", qualities[q], trackID)
+			fmt.Printf("\033[33mQuality fallback to %s for track %s\033[0m\n", Qualities[q], trackID)
 			return info, nil
 		}
 	}
@@ -1028,7 +1029,6 @@ func cleanTmp(dir string) {
 
 var (
 	reRemaster = regexp.MustCompile(`(?i)(re)?master(ed)?`)
-	reExtra    = regexp.MustCompile(`(?i)(anniversary|deluxe|live|collector|demo|expanded)`)
 	reEssence  = regexp.MustCompile(`^([^(]+)`)
 )
 
@@ -1069,7 +1069,7 @@ func smartDiscogFilter(requestedArtist string, items []map[string]interface{}) [
 
 		remasterExists := false
 		for _, a := range albums {
-			if isAlbumType("remaster", a) {
+			if isRemaster(a) {
 				remasterExists = true
 				break
 			}
@@ -1080,7 +1080,7 @@ func smartDiscogFilter(requestedArtist string, items []map[string]interface{}) [
 			sr, _ := a["maximum_sampling_rate"].(float64)
 			aName := nestedStr(a, "artist", "name")
 			if bd == bestBD && sr == bestSR && aName == requestedArtist &&
-				!(remasterExists && !isAlbumType("remaster", a)) {
+				!(remasterExists && !isRemaster(a)) {
 				result = append(result, a)
 				break
 			}
@@ -1097,17 +1097,12 @@ func essenceTitle(title string) string {
 	return strings.ToLower(strings.TrimSpace(m))
 }
 
-func isAlbumType(t string, album map[string]interface{}) bool {
+// isRemaster reports whether the album's title or version marks it as a
+// remaster.
+func isRemaster(album map[string]interface{}) bool {
 	title, _ := album["title"].(string)
 	version, _ := album["version"].(string)
-	combined := title + " " + version
-	switch t {
-	case "remaster":
-		return reRemaster.MatchString(combined)
-	case "extra":
-		return reExtra.MatchString(combined)
-	}
-	return false
+	return reRemaster.MatchString(title + " " + version)
 }
 
 // ---- format string helpers ----

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -66,9 +66,11 @@ type Downloader struct {
 
 	// Test seams, mirroring the pattern in lyrics.Client. retryDelay is the
 	// base of the download backoff (doubling each attempt); progressOut
-	// redirects the mpb bars away from stdout when non-nil.
+	// redirects the mpb bars away from stdout when non-nil; lastfmBase
+	// overrides the Last.fm API root.
 	retryDelay  time.Duration
 	progressOut io.Writer
+	lastfmBase  string
 }
 
 // New creates a Downloader. Returns an error if the download directory cannot

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -63,6 +63,12 @@ type Downloader struct {
 	Opts       Options
 	db         *downloadDB
 	httpClient *http.Client
+
+	// Test seams, mirroring the pattern in lyrics.Client. retryDelay is the
+	// base of the download backoff (doubling each attempt); progressOut
+	// redirects the mpb bars away from stdout when non-nil.
+	retryDelay  time.Duration
+	progressOut io.Writer
 }
 
 // New creates a Downloader. Returns an error if the download directory cannot
@@ -88,6 +94,7 @@ func New(client *api.Client, opts Options) (*Downloader, error) {
 		Client:     client,
 		Opts:       opts,
 		httpClient: &http.Client{Timeout: 10 * time.Minute},
+		retryDelay: time.Second,
 	}
 	if !opts.NoDB && opts.DBPath != "" {
 		db, err := openDB(opts.DBPath)
@@ -285,7 +292,7 @@ func (d *Downloader) downloadAlbum(ctx context.Context, albumID, baseDir string)
 	trackFmt := cleanFormatStr(d.Opts.TrackFormat, fileFormat)
 	isMP3 := d.Opts.Quality == 5
 
-	p := mpb.NewWithContext(ctx, mpb.WithRefreshRate(150*time.Millisecond))
+	p := d.newProgress(ctx)
 	jobs := d.collectTrackJobs(ctx, p, rawItems, albumDir, isMultiDisc)
 	d.runTrackJobs(ctx, jobs, meta, isMP3, trackFmt)
 	p.Wait()
@@ -523,7 +530,7 @@ func (d *Downloader) downloadTrackByID(ctx context.Context, trackID, baseDir str
 	if tn, ok := meta["track_number"].(float64); ok {
 		trackNum = int(tn)
 	}
-	p := mpb.NewWithContext(ctx, mpb.WithRefreshRate(150*time.Millisecond))
+	p := d.newProgress(ctx)
 	bar := p.New(0,
 		mpb.BarStyle().Lbound("╢").Filler("█").Tip("█").Padding("░").Rbound("╟"),
 		mpb.PrependDecorators(decor.Name(barLabel(trackNum, title))),
@@ -704,7 +711,7 @@ func (d *Downloader) downloadWithProgress(ctx context.Context, rawURL, dest stri
 	)
 
 	for attempt := 0; attempt < maxDownloadRetries; attempt++ {
-		if err := waitBeforeRetry(ctx, attempt); err != nil {
+		if err := d.waitBeforeRetry(ctx, attempt); err != nil {
 			return err
 		}
 
@@ -791,20 +798,33 @@ func (d *Downloader) downloadWithProgress(ctx context.Context, rawURL, dest stri
 	return fmt.Errorf("download failed after %d attempts", maxDownloadRetries)
 }
 
-// waitBeforeRetry sleeps with exponential backoff (1s, 2s, 4s, 8s) before a
-// retry attempt. attempt 0 is the first try and returns immediately. Returns
-// ctx.Err() if the context is cancelled while sleeping.
-func waitBeforeRetry(ctx context.Context, attempt int) error {
+// waitBeforeRetry sleeps with exponential backoff (1s, 2s, 4s, 8s by default)
+// before a retry attempt. attempt 0 is the first try and returns immediately.
+// Returns ctx.Err() if the context is cancelled while sleeping.
+func (d *Downloader) waitBeforeRetry(ctx context.Context, attempt int) error {
 	if attempt == 0 {
 		return nil
 	}
-	delay := time.Duration(1<<(attempt-1)) * time.Second
+	base := d.retryDelay
+	if base <= 0 {
+		base = time.Second
+	}
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-time.After(delay):
+	case <-time.After(base << (attempt - 1)):
 		return nil
 	}
+}
+
+// newProgress builds the mpb container for a download. Tests set progressOut
+// to keep the bars' ANSI redraws out of the test log.
+func (d *Downloader) newProgress(ctx context.Context) *mpb.Progress {
+	opts := []mpb.ContainerOption{mpb.WithRefreshRate(150 * time.Millisecond)}
+	if d.progressOut != nil {
+		opts = append(opts, mpb.WithOutput(d.progressOut))
+	}
+	return mpb.NewWithContext(ctx, opts...)
 }
 
 // currentOffset reports the size of an existing partial file at dest, or 0 if

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -1300,7 +1300,7 @@ func Search(ctx context.Context, client *api.Client, itemType, query string, lim
 		}
 		text := renderFormat(format, m)
 		if requiresExtra {
-			dur := formatDuration(int(getFloat(m, "duration")))
+			dur := formatDuration(int(nestedFloat(m, "duration")))
 			hires := "LOSSLESS"
 			if b, _ := m["hires_streamable"].(bool); b {
 				hires = "HI-RES"
@@ -1348,11 +1348,6 @@ func formatDuration(secs int) string {
 		return fmt.Sprintf("%02d:%02d:%02d", h, m, s)
 	}
 	return fmt.Sprintf("%02d:%02d", m, s)
-}
-
-func getFloat(m map[string]interface{}, key string) float64 {
-	v, _ := m[key].(float64)
-	return v
 }
 
 // ---- lucky search helper used by CLI ----

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -125,7 +125,7 @@ func (d *Downloader) HandleURL(ctx context.Context, rawURL string) error {
 		if err != nil {
 			return err
 		}
-		return d.downloadArtist(ctx, pages)
+		return d.downloadAlbumCollection(ctx, pages, "albums", "discography", d.Opts.SmartDiscog)
 	case "playlist":
 		pages, err := d.Client.GetPlaylistMeta(ctx, itemID)
 		if err != nil {
@@ -137,7 +137,7 @@ func (d *Downloader) HandleURL(ctx context.Context, rawURL string) error {
 		if err != nil {
 			return err
 		}
-		return d.downloadLabelOrArtist(ctx, pages, "albums", "label")
+		return d.downloadAlbumCollection(ctx, pages, "albums", "label", false)
 	default:
 		return fmt.Errorf("unsupported URL type: %s", urlType)
 	}
@@ -145,15 +145,12 @@ func (d *Downloader) HandleURL(ctx context.Context, rawURL string) error {
 
 // ---- collection downloads ----
 
-func (d *Downloader) downloadArtist(ctx context.Context, pages []map[string]interface{}) error {
-	if len(pages) == 0 {
-		return nil
-	}
-	name, _ := pages[0]["name"].(string)
-
+// collectPageItems flattens the items of every page under the given section
+// key (e.g. "albums", "tracks"), skipping pages that lack the section.
+func collectPageItems(pages []map[string]interface{}, key string) []map[string]interface{} {
 	var items []map[string]interface{}
 	for _, page := range pages {
-		section, _ := page["albums"].(map[string]interface{})
+		section, _ := page[key].(map[string]interface{})
 		if section == nil {
 			continue
 		}
@@ -164,16 +161,28 @@ func (d *Downloader) downloadArtist(ctx context.Context, pages []map[string]inte
 			}
 		}
 	}
+	return items
+}
 
-	if d.Opts.SmartDiscog {
+// downloadAlbumCollection downloads every album listed under itemKey in pages
+// into a directory named after the collection. kind names the collection in
+// the console output. smartDiscog applies the discography filter, which only
+// makes sense when the albums all belong to the collection's own artist.
+func (d *Downloader) downloadAlbumCollection(ctx context.Context, pages []map[string]interface{}, itemKey, kind string, smartDiscog bool) error {
+	if len(pages) == 0 {
+		return nil
+	}
+	name, _ := pages[0]["name"].(string)
+	items := collectPageItems(pages, itemKey)
+	if smartDiscog {
 		items = smartDiscogFilter(name, items)
 	}
 
 	dir := filepath.Join(d.Opts.Directory, sanitize(name))
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("create artist directory %q: %w", dir, err)
+		return fmt.Errorf("create %s directory %q: %w", kind, dir, err)
 	}
-	fmt.Printf("\033[33mDownloading discography: %s (%d albums)\033[0m\n", name, len(items))
+	fmt.Printf("\033[33mDownloading %s: %s (%d albums)\033[0m\n", kind, name, len(items))
 
 	for _, item := range items {
 		id := idStr(item["id"])
@@ -194,20 +203,7 @@ func (d *Downloader) downloadPlaylist(ctx context.Context, pages []map[string]in
 		return fmt.Errorf("create playlist directory %q: %w", dir, err)
 	}
 
-	var items []map[string]interface{}
-	for _, page := range pages {
-		section, _ := page["tracks"].(map[string]interface{})
-		if section == nil {
-			continue
-		}
-		raw, _ := section["items"].([]interface{})
-		for _, r := range raw {
-			if m, ok := r.(map[string]interface{}); ok {
-				items = append(items, m)
-			}
-		}
-	}
-
+	items := collectPageItems(pages, "tracks")
 	fmt.Printf("\033[33mDownloading playlist: %s (%d tracks)\033[0m\n", name, len(items))
 	for _, item := range items {
 		id := idStr(item["id"])
@@ -218,40 +214,6 @@ func (d *Downloader) downloadPlaylist(ctx context.Context, pages []map[string]in
 
 	if !d.Opts.NoM3U {
 		makeM3U(dir)
-	}
-	return nil
-}
-
-func (d *Downloader) downloadLabelOrArtist(ctx context.Context, pages []map[string]interface{}, itemKey, collectionType string) error {
-	if len(pages) == 0 {
-		return nil
-	}
-	name, _ := pages[0]["name"].(string)
-	dir := filepath.Join(d.Opts.Directory, sanitize(name))
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("create %s directory %q: %w", collectionType, dir, err)
-	}
-
-	var items []map[string]interface{}
-	for _, page := range pages {
-		section, _ := page[itemKey].(map[string]interface{})
-		if section == nil {
-			continue
-		}
-		raw, _ := section["items"].([]interface{})
-		for _, r := range raw {
-			if m, ok := r.(map[string]interface{}); ok {
-				items = append(items, m)
-			}
-		}
-	}
-
-	fmt.Printf("\033[33mDownloading %s: %s (%d albums)\033[0m\n", collectionType, name, len(items))
-	for _, item := range items {
-		id := idStr(item["id"])
-		if err := d.downloadAlbum(ctx, id, dir); err != nil {
-			fmt.Printf("\033[31mError on album %s: %v. Skipping...\033[0m\n", id, err)
-		}
 	}
 	return nil
 }

--- a/internal/downloader/helpers_test.go
+++ b/internal/downloader/helpers_test.go
@@ -233,25 +233,20 @@ func TestEssenceTitle(t *testing.T) {
 
 // ---- isAlbumType --------------------------------------------------------
 
-func TestIsAlbumType(t *testing.T) {
+func TestIsRemaster(t *testing.T) {
 	cases := []struct {
-		albumType string
-		album     map[string]interface{}
-		want      bool
+		album map[string]interface{}
+		want  bool
 	}{
-		{"remaster", map[string]interface{}{"title": "Dark Side (Remastered)", "version": ""}, true},
-		{"remaster", map[string]interface{}{"title": "OK Computer", "version": ""}, false},
-		{"remaster", map[string]interface{}{"title": "OK Computer", "version": "Remastered"}, true},
-		{"extra", map[string]interface{}{"title": "Deluxe Edition", "version": ""}, true},
-		{"extra", map[string]interface{}{"title": "Anniversary Edition", "version": ""}, true},
-		{"extra", map[string]interface{}{"title": "Normal Album", "version": ""}, false},
-		{"extra", map[string]interface{}{"title": "Normal", "version": "Live at MSG"}, true},
-		{"unknown", map[string]interface{}{"title": "Anything", "version": ""}, false},
+		{map[string]interface{}{"title": "Dark Side (Remastered)", "version": ""}, true},
+		{map[string]interface{}{"title": "OK Computer", "version": ""}, false},
+		{map[string]interface{}{"title": "OK Computer", "version": "Remastered"}, true},
+		{map[string]interface{}{"title": "Deluxe Edition", "version": ""}, false},
+		{map[string]interface{}{}, false},
 	}
 	for _, c := range cases {
-		got := isAlbumType(c.albumType, c.album)
-		if got != c.want {
-			t.Errorf("isAlbumType(%q, %v) = %v, want %v", c.albumType, c.album, got, c.want)
+		if got := isRemaster(c.album); got != c.want {
+			t.Errorf("isRemaster(%v) = %v, want %v", c.album, got, c.want)
 		}
 	}
 }

--- a/internal/downloader/integration_test.go
+++ b/internal/downloader/integration_test.go
@@ -1,0 +1,703 @@
+package downloader
+
+// integration_test.go — end-to-end tests that drive the downloader against a
+// mock Qobuz API and a mock CDN, plus focused tests for the resume/retry
+// machinery in downloadWithProgress.
+//
+// Everything is stdlib: net/http/httptest for the servers, no fixtures on
+// disk beyond t.TempDir().
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Aeneaj/qobuz-dl-go/internal/api"
+)
+
+// ---- CDN mock: a file server that can fail in the ways real ones do -------
+
+// flakyCDN serves payload over HTTP with controllable misbehaviour, so each
+// branch of the resume logic can be driven deliberately.
+type flakyCDN struct {
+	payload []byte
+
+	// failAfter > 0 drops the connection after writing that many bytes of the
+	// body, for the first failTimes requests. This is what a mid-download
+	// server drop looks like to the client: io.ErrUnexpectedEOF.
+	failAfter int
+	failTimes int
+
+	// ignoreRange makes the server answer 200 with the whole body even when
+	// the client asked for a byte range — some CDNs really do this.
+	ignoreRange bool
+
+	// status, when non-zero, is returned instead of serving the body.
+	status int
+
+	mu     sync.Mutex
+	ranges []string // Range header of every request received, in order
+}
+
+func (f *flakyCDN) handler(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	f.ranges = append(f.ranges, r.Header.Get("Range"))
+	n := len(f.ranges)
+	f.mu.Unlock()
+
+	if f.status != 0 {
+		w.WriteHeader(f.status)
+		return
+	}
+
+	start := 0
+	if rng := r.Header.Get("Range"); rng != "" && !f.ignoreRange {
+		fmt.Sscanf(rng, "bytes=%d-", &start)
+		if start > len(f.payload) {
+			start = len(f.payload)
+		}
+		w.Header().Set("Content-Range",
+			fmt.Sprintf("bytes %d-%d/%d", start, len(f.payload)-1, len(f.payload)))
+		w.Header().Set("Content-Length", strconv.Itoa(len(f.payload)-start))
+		w.WriteHeader(http.StatusPartialContent)
+	} else {
+		w.Header().Set("Content-Length", strconv.Itoa(len(f.payload)))
+		w.WriteHeader(http.StatusOK)
+	}
+
+	body := f.payload[start:]
+	if f.failAfter > 0 && n <= f.failTimes {
+		if f.failAfter < len(body) {
+			body = body[:f.failAfter]
+		}
+		w.Write(body)
+		if fl, ok := w.(http.Flusher); ok {
+			fl.Flush()
+		}
+		// Abort without finishing the declared Content-Length. net/http
+		// recognises this sentinel and drops the connection quietly.
+		panic(http.ErrAbortHandler)
+	}
+	w.Write(body)
+}
+
+func (f *flakyCDN) rangeHeaders() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.ranges...)
+}
+
+// testDownloader builds a Downloader wired for tests: near-zero retry backoff
+// and progress bars sent to io.Discard instead of the terminal.
+func testDownloader(t *testing.T, opts Options) *Downloader {
+	t.Helper()
+	if opts.Directory == "" {
+		opts.Directory = t.TempDir()
+	}
+	d, err := New(nil, opts)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	d.retryDelay = time.Millisecond
+	d.progressOut = io.Discard
+	return d
+}
+
+// ---- downloadWithProgress ------------------------------------------------
+
+func TestDownloadWithProgress_Plain(t *testing.T) {
+	cdn := &flakyCDN{payload: bytes.Repeat([]byte("abcd"), 64)}
+	srv := httptest.NewServer(http.HandlerFunc(cdn.handler))
+	defer srv.Close()
+
+	d := testDownloader(t, Options{})
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	if err := d.downloadWithProgress(context.Background(), srv.URL, dest, nil); err != nil {
+		t.Fatalf("downloadWithProgress: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, cdn.payload) {
+		t.Errorf("got %d bytes, want %d", len(got), len(cdn.payload))
+	}
+	if n := len(cdn.rangeHeaders()); n != 1 {
+		t.Errorf("made %d requests, want 1", n)
+	}
+}
+
+// A drop mid-body must be resumed with a Range request, not restarted, and
+// the bytes already on disk must not be duplicated.
+func TestDownloadWithProgress_ResumesAfterDrop(t *testing.T) {
+	cdn := &flakyCDN{
+		payload:   bytes.Repeat([]byte("xyz!"), 64), // 256 bytes
+		failAfter: 100,
+		failTimes: 1,
+	}
+	srv := httptest.NewServer(http.HandlerFunc(cdn.handler))
+	defer srv.Close()
+
+	d := testDownloader(t, Options{})
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	if err := d.downloadWithProgress(context.Background(), srv.URL, dest, nil); err != nil {
+		t.Fatalf("downloadWithProgress: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, cdn.payload) {
+		t.Fatalf("file is %d bytes, want %d — resume corrupted it", len(got), len(cdn.payload))
+	}
+
+	reqs := cdn.rangeHeaders()
+	if len(reqs) != 2 {
+		t.Fatalf("made %d requests, want 2 (initial + resume): %v", len(reqs), reqs)
+	}
+	if reqs[0] != "" {
+		t.Errorf("first request sent Range %q, want none", reqs[0])
+	}
+	if reqs[1] != "bytes=100-" {
+		t.Errorf("resume asked for %q, want %q", reqs[1], "bytes=100-")
+	}
+}
+
+// A server that answers a Range request with 200 and the whole body would
+// duplicate the partial bytes if appended. The partial file must be discarded.
+func TestDownloadWithProgress_ServerIgnoresRange(t *testing.T) {
+	cdn := &flakyCDN{
+		payload:     bytes.Repeat([]byte("0123456789"), 30), // 300 bytes
+		failAfter:   120,
+		failTimes:   1,
+		ignoreRange: true,
+	}
+	srv := httptest.NewServer(http.HandlerFunc(cdn.handler))
+	defer srv.Close()
+
+	d := testDownloader(t, Options{})
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	if err := d.downloadWithProgress(context.Background(), srv.URL, dest, nil); err != nil {
+		t.Fatalf("downloadWithProgress: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, cdn.payload) {
+		t.Errorf("file is %d bytes, want %d — partial data was not discarded",
+			len(got), len(cdn.payload))
+	}
+}
+
+func TestDownloadWithProgress_GivesUpAfterMaxRetries(t *testing.T) {
+	cdn := &flakyCDN{
+		payload:   bytes.Repeat([]byte("z"), 200),
+		failAfter: 10,
+		failTimes: 99, // never succeeds
+	}
+	srv := httptest.NewServer(http.HandlerFunc(cdn.handler))
+	defer srv.Close()
+
+	d := testDownloader(t, Options{})
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	err := d.downloadWithProgress(context.Background(), srv.URL, dest, nil)
+	if err == nil {
+		t.Fatal("expected an error once the retries ran out")
+	}
+	if n := len(cdn.rangeHeaders()); n != maxDownloadRetries {
+		t.Errorf("made %d attempts, want %d", n, maxDownloadRetries)
+	}
+}
+
+// A 4xx is not a transient failure: it must surface immediately.
+func TestDownloadWithProgress_HTTPErrorIsNotRetried(t *testing.T) {
+	cdn := &flakyCDN{status: http.StatusNotFound}
+	srv := httptest.NewServer(http.HandlerFunc(cdn.handler))
+	defer srv.Close()
+
+	d := testDownloader(t, Options{})
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	err := d.downloadWithProgress(context.Background(), srv.URL, dest, nil)
+	if err == nil {
+		t.Fatal("expected an error for HTTP 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error should mention the status: %v", err)
+	}
+	if n := len(cdn.rangeHeaders()); n != 1 {
+		t.Errorf("made %d requests, want 1 — a 404 must not be retried", n)
+	}
+}
+
+func TestDownloadWithProgress_ContextCancelled(t *testing.T) {
+	cdn := &flakyCDN{
+		payload:   bytes.Repeat([]byte("q"), 200),
+		failAfter: 10,
+		failTimes: 99,
+	}
+	srv := httptest.NewServer(http.HandlerFunc(cdn.handler))
+	defer srv.Close()
+
+	d := testDownloader(t, Options{})
+	d.retryDelay = time.Hour // the wait must be interrupted, not waited out
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- d.downloadWithProgress(ctx, srv.URL, filepath.Join(t.TempDir(), "out.bin"), nil)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error after cancellation")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancellation did not interrupt the retry backoff")
+	}
+}
+
+// ---- Qobuz API mock ------------------------------------------------------
+
+// qobuzMock stands in for both the Qobuz API and the CDN it hands URLs out
+// for. Album metadata is supplied by the test; track audio is a valid minimal
+// FLAC so the real tagging code runs.
+type qobuzMock struct {
+	srv   *httptest.Server
+	album map[string]interface{}
+	audio []byte
+
+	mu       sync.Mutex
+	fileHits int
+}
+
+func newQobuzMock(t *testing.T, album map[string]interface{}) *qobuzMock {
+	t.Helper()
+	m := &qobuzMock{album: album, audio: makeFakeFLAC()}
+	m.srv = httptest.NewServer(http.HandlerFunc(m.route))
+	t.Cleanup(m.srv.Close)
+	return m
+}
+
+func (m *qobuzMock) route(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/album/get":
+		json.NewEncoder(w).Encode(m.album)
+
+	case r.URL.Path == "/track/get":
+		json.NewEncoder(w).Encode(m.trackByID(r.URL.Query().Get("track_id")))
+
+	case r.URL.Path == "/track/getFileUrl":
+		id := r.URL.Query().Get("track_id")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"url":           m.srv.URL + "/audio/" + id,
+			"bit_depth":     16,
+			"sampling_rate": 44.1,
+			"format_id":     6,
+		})
+
+	case strings.HasPrefix(r.URL.Path, "/audio/"):
+		m.mu.Lock()
+		m.fileHits++
+		m.mu.Unlock()
+		w.Header().Set("Content-Length", strconv.Itoa(len(m.audio)))
+		w.Write(m.audio)
+
+	case r.URL.Path == "/artist/get":
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"name":         "Test Artist",
+			"albums_count": 1,
+			"albums": map[string]interface{}{"items": []interface{}{
+				map[string]interface{}{"id": "alb1", "title": "Test Album"},
+			}},
+		})
+
+	case r.URL.Path == "/playlist/get":
+		items := make([]interface{}, 0, len(m.tracks()))
+		for _, tr := range m.tracks() {
+			items = append(items, tr)
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"name":         "My Playlist",
+			"tracks_count": len(items),
+			"tracks":       map[string]interface{}{"items": items},
+		})
+
+	case r.URL.Path == "/cover.jpg":
+		w.Write([]byte("\xff\xd8\xff\xe0JFIF-ish cover bytes"))
+
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// trackByID finds a track in the album tracklist and returns it with the
+// album attached, which is the shape track/get returns.
+func (m *qobuzMock) trackByID(id string) map[string]interface{} {
+	for _, raw := range m.tracks() {
+		if idStr(raw["id"]) == id {
+			out := map[string]interface{}{}
+			for k, v := range raw {
+				out[k] = v
+			}
+			out["album"] = m.album
+			return out
+		}
+	}
+	return map[string]interface{}{}
+}
+
+func (m *qobuzMock) tracks() []map[string]interface{} {
+	section, _ := m.album["tracks"].(map[string]interface{})
+	raw, _ := section["items"].([]interface{})
+	var out []map[string]interface{}
+	for _, r := range raw {
+		if t, ok := r.(map[string]interface{}); ok {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// downloaderFor wires a Downloader to the mock, with predictable name formats
+// so the assertions can name exact paths.
+func (m *qobuzMock) downloaderFor(t *testing.T, mutate func(*Options)) (*Downloader, string) {
+	t.Helper()
+	dir := t.TempDir()
+	opts := Options{
+		Directory:    dir,
+		Quality:      6,
+		FolderFormat: "{artist} - {album}",
+		TrackFormat:  "{tracknumber}. {tracktitle}",
+		DBPath:       filepath.Join(t.TempDir(), "downloads.db"),
+		Workers:      2,
+		NoM3U:        true,
+	}
+	if mutate != nil {
+		mutate(&opts)
+	}
+	d := testDownloader(t, opts)
+	d.Client = apiClientFor(m.srv)
+	return d, dir
+}
+
+func track(id int, num int, disc int, title string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":           float64(id),
+		"track_number": float64(num),
+		"media_number": float64(disc),
+		"title":        title,
+		"performer":    map[string]interface{}{"name": "Test Artist"},
+	}
+}
+
+func testAlbum(coverURL string, tracks ...map[string]interface{}) map[string]interface{} {
+	items := make([]interface{}, len(tracks))
+	for i, t := range tracks {
+		items[i] = t
+	}
+	return map[string]interface{}{
+		"id":                    "alb1",
+		"title":                 "Test Album",
+		"streamable":            true,
+		"release_date_original": "2024-03-01",
+		"tracks_count":          float64(len(tracks)),
+		"artist":                map[string]interface{}{"name": "Test Artist"},
+		"image":                 map[string]interface{}{"large": coverURL},
+		"genres_list":           []interface{}{"Pop/Rock"},
+		"tracks":                map[string]interface{}{"items": items},
+	}
+}
+
+// ---- full album flow -----------------------------------------------------
+
+func TestDownloadAlbum_EndToEnd(t *testing.T) {
+	m := newQobuzMock(t, nil)
+	m.album = testAlbum(m.srv.URL+"/cover.jpg",
+		track(101, 1, 1, "Song One"),
+		track(102, 2, 1, "Song Two"),
+	)
+	d, dir := m.downloaderFor(t, nil)
+
+	if err := d.downloadAlbum(context.Background(), "alb1", dir); err != nil {
+		t.Fatalf("downloadAlbum: %v", err)
+	}
+
+	albumDir := filepath.Join(dir, "Test Artist - Test Album")
+	for _, name := range []string{"01. Song One.flac", "02. Song Two.flac", "cover.jpg"} {
+		if _, err := os.Stat(filepath.Join(albumDir, name)); err != nil {
+			t.Errorf("missing %s: %v", name, err)
+		}
+	}
+
+	// The downloaded file must be a tagged FLAC, not the raw bytes we served.
+	data, err := os.ReadFile(filepath.Join(albumDir, "01. Song One.flac"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data[:4]) != "fLaC" {
+		t.Error("output is not a FLAC file")
+	}
+	for _, want := range []string{"TITLE=Song One", "ARTIST=Test Artist", "ALBUM=Test Album"} {
+		if !bytes.Contains(data, []byte(want)) {
+			t.Errorf("tag %q missing from the written file", want)
+		}
+	}
+
+	// Both tracks recorded in the downloads DB.
+	db, err := os.ReadFile(d.Opts.DBPath)
+	if err != nil {
+		t.Fatalf("downloads DB not written: %v", err)
+	}
+	for _, id := range []string{"101", "102"} {
+		if !strings.Contains(string(db), id) {
+			t.Errorf("track %s not recorded in the DB: %q", id, db)
+		}
+	}
+
+	assertNoTmpFiles(t, dir)
+}
+
+func TestDownloadAlbum_MultiDiscUsesSubdirs(t *testing.T) {
+	m := newQobuzMock(t, nil)
+	m.album = testAlbum(m.srv.URL+"/cover.jpg",
+		track(201, 1, 1, "Disc One Opener"),
+		track(202, 1, 2, "Disc Two Opener"),
+	)
+	d, dir := m.downloaderFor(t, nil)
+
+	if err := d.downloadAlbum(context.Background(), "alb1", dir); err != nil {
+		t.Fatalf("downloadAlbum: %v", err)
+	}
+
+	albumDir := filepath.Join(dir, "Test Artist - Test Album")
+	for _, rel := range []string{
+		filepath.Join("Disc 1", "01. Disc One Opener.flac"),
+		filepath.Join("Disc 2", "01. Disc Two Opener.flac"),
+	} {
+		if _, err := os.Stat(filepath.Join(albumDir, rel)); err != nil {
+			t.Errorf("missing %s: %v", rel, err)
+		}
+	}
+}
+
+func TestDownloadAlbum_SkipsTracksAlreadyInDB(t *testing.T) {
+	m := newQobuzMock(t, nil)
+	m.album = testAlbum(m.srv.URL+"/cover.jpg",
+		track(301, 1, 1, "Already Have It"),
+		track(302, 2, 1, "Fetch This One"),
+	)
+
+	dbPath := filepath.Join(t.TempDir(), "downloads.db")
+	if err := os.WriteFile(dbPath, []byte("301\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	d, dir := m.downloaderFor(t, func(o *Options) { o.DBPath = dbPath })
+
+	if err := d.downloadAlbum(context.Background(), "alb1", dir); err != nil {
+		t.Fatalf("downloadAlbum: %v", err)
+	}
+
+	albumDir := filepath.Join(dir, "Test Artist - Test Album")
+	if _, err := os.Stat(filepath.Join(albumDir, "01. Already Have It.flac")); err == nil {
+		t.Error("track listed in the DB was downloaded again")
+	}
+	if _, err := os.Stat(filepath.Join(albumDir, "02. Fetch This One.flac")); err != nil {
+		t.Errorf("new track was not downloaded: %v", err)
+	}
+}
+
+func TestDownloadAlbum_SkipsNonStreamable(t *testing.T) {
+	m := newQobuzMock(t, nil)
+	m.album = testAlbum(m.srv.URL+"/cover.jpg", track(401, 1, 1, "Blocked"))
+	m.album["streamable"] = false
+	d, dir := m.downloaderFor(t, nil)
+
+	if err := d.downloadAlbum(context.Background(), "alb1", dir); err != nil {
+		t.Fatalf("downloadAlbum: %v", err)
+	}
+	if m.fileHits != 0 {
+		t.Errorf("fetched %d files from a non-streamable album, want 0", m.fileHits)
+	}
+}
+
+// An existing output file short-circuits the download entirely.
+func TestDownloadAlbum_SkipsExistingFiles(t *testing.T) {
+	m := newQobuzMock(t, nil)
+	m.album = testAlbum(m.srv.URL+"/cover.jpg", track(501, 1, 1, "On Disk"))
+	d, dir := m.downloaderFor(t, func(o *Options) { o.NoDB = true })
+
+	albumDir := filepath.Join(dir, "Test Artist - Test Album")
+	if err := os.MkdirAll(albumDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	existing := filepath.Join(albumDir, "01. On Disk.flac")
+	if err := os.WriteFile(existing, []byte("untouched"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.downloadAlbum(context.Background(), "alb1", dir); err != nil {
+		t.Fatalf("downloadAlbum: %v", err)
+	}
+
+	got, err := os.ReadFile(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "untouched" {
+		t.Error("an already-downloaded file was overwritten")
+	}
+}
+
+func TestHandleURL_TrackDownloadsSingleFile(t *testing.T) {
+	m := newQobuzMock(t, nil)
+	m.album = testAlbum(m.srv.URL+"/cover.jpg", track(601, 3, 1, "Lonely Track"))
+	d, dir := m.downloaderFor(t, nil)
+
+	if err := d.HandleURL(context.Background(), "https://open.qobuz.com/track/601"); err != nil {
+		t.Fatalf("HandleURL: %v", err)
+	}
+
+	path := filepath.Join(dir, "Test Artist - Test Album", "03. Lonely Track.flac")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("track not downloaded: %v", err)
+	}
+	if !bytes.Contains(data, []byte("TITLE=Lonely Track")) {
+		t.Error("single-track download was not tagged")
+	}
+	assertNoTmpFiles(t, dir)
+}
+
+// ---- collection flows ----------------------------------------------------
+
+// collectPageItems is the flattening step shared by the artist, label and
+// playlist flows; paginated responses are the case worth pinning down.
+func TestCollectPageItems(t *testing.T) {
+	page := func(key string, ids ...string) map[string]interface{} {
+		items := make([]interface{}, len(ids))
+		for i, id := range ids {
+			items[i] = map[string]interface{}{"id": id}
+		}
+		return map[string]interface{}{key: map[string]interface{}{"items": items}}
+	}
+
+	cases := []struct {
+		name  string
+		pages []map[string]interface{}
+		key   string
+		want  []string
+	}{
+		{"single page", []map[string]interface{}{page("albums", "a", "b")}, "albums", []string{"a", "b"}},
+		{
+			"across pages",
+			[]map[string]interface{}{page("albums", "a"), page("albums", "b", "c")},
+			"albums", []string{"a", "b", "c"},
+		},
+		{"missing section is skipped", []map[string]interface{}{{"name": "x"}, page("albums", "a")}, "albums", []string{"a"}},
+		{"wrong key", []map[string]interface{}{page("albums", "a")}, "tracks", nil},
+		{"no pages", nil, "albums", nil},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := collectPageItems(c.pages, c.key)
+			if len(got) != len(c.want) {
+				t.Fatalf("got %d items, want %d", len(got), len(c.want))
+			}
+			for i, want := range c.want {
+				if id := idStr(got[i]["id"]); id != want {
+					t.Errorf("item %d = %q, want %q", i, id, want)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleURL_ArtistDownloadsDiscography(t *testing.T) {
+	m := newQobuzMock(t, nil)
+	m.album = testAlbum(m.srv.URL+"/cover.jpg", track(701, 1, 1, "Discog Track"))
+	d, dir := m.downloaderFor(t, nil)
+
+	if err := d.HandleURL(context.Background(), "https://open.qobuz.com/artist/55"); err != nil {
+		t.Fatalf("HandleURL: %v", err)
+	}
+
+	// Discography goes under a directory named after the artist, and each
+	// album keeps its own folder inside it.
+	path := filepath.Join(dir, "Test Artist", "Test Artist - Test Album", "01. Discog Track.flac")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("missing %s: %v", path, err)
+	}
+}
+
+func TestHandleURL_PlaylistWritesM3U(t *testing.T) {
+	m := newQobuzMock(t, nil)
+	m.album = testAlbum(m.srv.URL+"/cover.jpg",
+		track(801, 1, 1, "Playlist Track"),
+	)
+	d, dir := m.downloaderFor(t, func(o *Options) { o.NoM3U = false })
+
+	if err := d.HandleURL(context.Background(), "https://open.qobuz.com/playlist/77"); err != nil {
+		t.Fatalf("HandleURL: %v", err)
+	}
+
+	playlistDir := filepath.Join(dir, "My Playlist")
+	m3u := filepath.Join(playlistDir, "My Playlist.m3u")
+	data, err := os.ReadFile(m3u)
+	if err != nil {
+		t.Fatalf("M3U not written: %v", err)
+	}
+	if !strings.HasPrefix(string(data), "#EXTM3U") {
+		t.Errorf("M3U missing its header: %q", data)
+	}
+	if !strings.Contains(string(data), "Playlist Track") {
+		t.Errorf("M3U does not list the downloaded track: %q", data)
+	}
+}
+
+// ---- helpers -------------------------------------------------------------
+
+// apiClientFor returns a real api.Client pointed at the mock server.
+func apiClientFor(srv *httptest.Server) *api.Client {
+	c := api.New("123456789", []string{"testsecret"})
+	c.BaseURL = srv.URL + "/"
+	c.Secret = "testsecret"
+	return c
+}
+
+func assertNoTmpFiles(t *testing.T, dir string) {
+	t.Helper()
+	err := filepath.WalkDir(dir, func(path string, e os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file: %s", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/downloader/integration_test.go
+++ b/internal/downloader/integration_test.go
@@ -287,8 +287,19 @@ type qobuzMock struct {
 	album map[string]interface{}
 	audio []byte
 
+	// searchMisses marks queries that track/search should answer with no
+	// results, so the "not on Qobuz" path can be exercised.
+	searchMisses map[string]bool
+
 	mu       sync.Mutex
 	fileHits int
+	searches []string
+}
+
+func (m *qobuzMock) searchQueries() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.searches...)
 }
 
 func newQobuzMock(t *testing.T, album map[string]interface{}) *qobuzMock {
@@ -322,6 +333,20 @@ func (m *qobuzMock) route(w http.ResponseWriter, r *http.Request) {
 		m.mu.Unlock()
 		w.Header().Set("Content-Length", strconv.Itoa(len(m.audio)))
 		w.Write(m.audio)
+
+	case r.URL.Path == "/track/search":
+		query := r.URL.Query().Get("query")
+		m.mu.Lock()
+		m.searches = append(m.searches, query)
+		m.mu.Unlock()
+
+		items := []interface{}{}
+		if !m.searchMisses[query] && len(m.tracks()) > 0 {
+			items = append(items, m.tracks()[0])
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"tracks": map[string]interface{}{"items": items},
+		})
 
 	case r.URL.Path == "/artist/get":
 		json.NewEncoder(w).Encode(map[string]interface{}{
@@ -587,6 +612,148 @@ func TestHandleURL_TrackDownloadsSingleFile(t *testing.T) {
 		t.Error("single-track download was not tagged")
 	}
 	assertNoTmpFiles(t, dir)
+}
+
+// ---- MP3 flow ------------------------------------------------------------
+
+// utf16le encodes s the way ID3v2.3 text frames carry it (BOM + LE units).
+// Deliberately independent of the production encoder.
+func utf16le(s string) []byte {
+	out := []byte{0xFF, 0xFE}
+	for _, r := range s {
+		out = append(out, byte(r), byte(r>>8))
+	}
+	return out
+}
+
+// Quality 5 takes the MP3 branch: .mp3 extension, ID3v2.3 tags and, with
+// EmbedArt, an APIC frame carrying the cover downloaded alongside the album.
+func TestDownloadAlbum_MP3TaggingEndToEnd(t *testing.T) {
+	m := newQobuzMock(t, nil)
+	m.album = testAlbum(m.srv.URL+"/cover.jpg", track(1001, 7, 2, "Mp3 Song"))
+	m.audio = []byte("\xff\xfb\x90\x00fake mpeg audio frames")
+
+	d, dir := m.downloaderFor(t, func(o *Options) {
+		o.Quality = 5
+		o.EmbedArt = true
+	})
+
+	if err := d.downloadAlbum(context.Background(), "alb1", dir); err != nil {
+		t.Fatalf("downloadAlbum: %v", err)
+	}
+
+	path := filepath.Join(dir, "Test Artist - Test Album", "07. Mp3 Song.mp3")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("MP3 not written: %v", err)
+	}
+
+	if string(data[:3]) != "ID3" || data[3] != 0x03 {
+		t.Fatalf("not an ID3v2.3 tag: % x", data[:5])
+	}
+	// Text frames are UTF-16LE with a BOM.
+	for frame, text := range map[string]string{
+		"TIT2": "Mp3 Song",
+		"TPE1": "Test Artist",
+		"TALB": "Test Album",
+		"TRCK": "7/1",
+		"TPOS": "2",
+	} {
+		if !bytes.Contains(data, []byte(frame)) {
+			t.Errorf("frame %s missing", frame)
+		}
+		if !bytes.Contains(data, utf16le(text)) {
+			t.Errorf("frame %s does not carry %q", frame, text)
+		}
+	}
+	// Cover embedded as APIC, and the audio payload survived the rewrite.
+	if !bytes.Contains(data, []byte("APIC")) {
+		t.Error("no APIC frame — cover was not embedded")
+	}
+	if !bytes.Contains(data, []byte("JFIF-ish cover bytes")) {
+		t.Error("APIC frame does not contain the downloaded cover")
+	}
+	if !bytes.HasSuffix(data, m.audio) {
+		t.Error("MPEG audio payload was lost or reordered")
+	}
+	assertNoTmpFiles(t, dir)
+}
+
+// buildMP3Tags has an album branch and a single-track branch that read their
+// fields from different places; only the album one runs during an album
+// download.
+func TestBuildMP3Tags_TrackBranch(t *testing.T) {
+	trackMeta := map[string]interface{}{
+		"title":        "Solo Song",
+		"track_number": float64(4),
+		"media_number": float64(1),
+		"performer":    map[string]interface{}{"name": "Performer"},
+		"composer":     map[string]interface{}{"name": "Composer"},
+		"copyright":    "(C) 2024",
+		"album": map[string]interface{}{
+			"title":                 "Parent Album",
+			"artist":                map[string]interface{}{"name": "Album Artist"},
+			"release_date_original": "2024-07-09",
+			"tracks_count":          float64(11),
+			"genres_list":           []interface{}{"Jazz"},
+			"label":                 map[string]interface{}{"name": "Label Co"},
+		},
+	}
+	tags := buildMP3Tags(trackMeta, nil, true)
+
+	want := map[string]string{
+		"TIT2": "Solo Song",
+		"TPE1": "Performer",
+		"TPE2": "Album Artist",
+		"TALB": "Parent Album",
+		"TCOM": "Composer",
+		"TDRC": "2024-07-09",
+		"TYER": "2024",
+		"TRCK": "4/11",
+		"TPOS": "1",
+		"TCON": "Jazz",
+		"TPUB": "Label Co",
+		"TCOP": "© 2024",
+	}
+	for k, v := range want {
+		if tags[k] != v {
+			t.Errorf("tag %s = %q, want %q", k, tags[k], v)
+		}
+	}
+}
+
+// findCover looks next to the track and then one directory up, which is where
+// the cover lives for multi-disc albums.
+func TestFindCover(t *testing.T) {
+	base := t.TempDir()
+	discDir := filepath.Join(base, "Disc 1")
+	if err := os.MkdirAll(discDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := findCover(discDir); got != "" {
+		t.Errorf("found %q when there is no cover anywhere", got)
+	}
+
+	parentCover := filepath.Join(base, "cover.jpg")
+	if err := os.WriteFile(parentCover, []byte("parent"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := findCover(discDir); got != parentCover {
+		t.Errorf("findCover = %q, want the parent cover %q", got, parentCover)
+	}
+
+	ownCover := filepath.Join(discDir, "cover.jpg")
+	if err := os.WriteFile(ownCover, []byte("own"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := findCover(discDir); got != ownCover {
+		t.Errorf("findCover = %q, want the local cover %q", got, ownCover)
+	}
+
+	if _, err := readCover(t.TempDir()); err == nil {
+		t.Error("readCover should fail when there is no cover")
+	}
 }
 
 // ---- collection flows ----------------------------------------------------

--- a/internal/downloader/interactive.go
+++ b/internal/downloader/interactive.go
@@ -154,11 +154,7 @@ func printQueue(queue []SearchResult) {
 	}
 	fmt.Printf("\n\033[33mQueue (%d item(s)):\033[0m\n", len(queue))
 	for i, r := range queue {
-		label := r.Text
-		if label == r.URL {
-			label = r.URL // direct URL entry
-		}
-		fmt.Printf("  \033[90m[%d]\033[0m %s\n", i+1, label)
+		fmt.Printf("  \033[90m[%d]\033[0m %s\n", i+1, r.Text)
 	}
 	fmt.Println()
 }

--- a/internal/downloader/lastfm.go
+++ b/internal/downloader/lastfm.go
@@ -54,12 +54,19 @@ func parseLastFMURL(rawURL string) (username, listType string, err error) {
 	return parts[1], parts[2], nil
 }
 
+// lastfmAPIBase is the root of the key-less Last.fm 1.0 API.
+const lastfmAPIBase = "https://ws.audioscrobbler.com/1.0/user/"
+
 // fetchLastFMTracks downloads and parses the XSPF playlist from the Last.fm
 // 1.0 API. No API key is required.
 //
 // Supported listType values: "loved", "library".
-func fetchLastFMTracks(ctx context.Context, username, listType string) ([]LastFMTrack, error) {
-	base := "https://ws.audioscrobbler.com/1.0/user/" + url.PathEscape(username) + "/"
+func (d *Downloader) fetchLastFMTracks(ctx context.Context, username, listType string) ([]LastFMTrack, error) {
+	root := d.lastfmBase
+	if root == "" {
+		root = lastfmAPIBase
+	}
+	base := root + url.PathEscape(username) + "/"
 	var xspfURL string
 	switch listType {
 	case "loved":
@@ -118,7 +125,7 @@ func (d *Downloader) downloadLastFMPlaylist(ctx context.Context, username, listT
 	}
 
 	fmt.Printf("\033[33mFetching Last.fm %s for user %q...\033[0m\n", label, username)
-	tracks, err := fetchLastFMTracks(ctx, username, listType)
+	tracks, err := d.fetchLastFMTracks(ctx, username, listType)
 	if err != nil {
 		return err
 	}

--- a/internal/downloader/lastfm_test.go
+++ b/internal/downloader/lastfm_test.go
@@ -5,6 +5,10 @@ import (
 	"encoding/xml"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -42,54 +46,191 @@ func TestParseLastFMURL(t *testing.T) {
 	}
 }
 
-func TestFetchLastFMTracks(t *testing.T) {
-	// Serve a minimal XSPF document from a local test server.
-	xspf := xspfPlaylist{
-		Title: "Test Playlist",
-		TrackList: []xspfTrack{
-			{Title: "Karma Police", Creator: "Radiohead"},
-			{Title: "No Surprises", Creator: "Radiohead"},
-			{Title: "", Creator: "Empty Artist"}, // should be skipped
-			{Title: "No Creator", Creator: ""},   // should be skipped
-		},
-	}
-	body, _ := xml.Marshal(xspf)
+// lastfmMock serves an XSPF playlist and records what was requested. Paths are
+// recorded still escaped, so username escaping stays observable.
+type lastfmMock struct {
+	srv *httptest.Server
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mu    sync.Mutex
+	paths []string
+}
+
+func newLastFMMock(t *testing.T, status int, body []byte) *lastfmMock {
+	t.Helper()
+	l := &lastfmMock{}
+	l.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		l.mu.Lock()
+		l.paths = append(l.paths, r.URL.EscapedPath())
+		l.mu.Unlock()
+
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
 		w.Header().Set("Content-Type", "application/xspf+xml")
 		w.Write(body)
 	}))
-	defer ts.Close()
-
-	// We can't inject the server URL into fetchLastFMTracks directly, so we
-	// test the XML parsing logic via the exported struct types.
-	var parsed xspfPlaylist
-	if err := xml.Unmarshal(body, &parsed); err != nil {
-		t.Fatalf("xml.Unmarshal: %v", err)
-	}
-
-	var tracks []LastFMTrack
-	for _, tr := range parsed.TrackList {
-		if tr.Creator != "" && tr.Title != "" {
-			tracks = append(tracks, LastFMTrack{Artist: tr.Creator, Title: tr.Title})
-		}
-	}
-
-	if len(tracks) != 2 {
-		t.Fatalf("expected 2 valid tracks, got %d", len(tracks))
-	}
-	if tracks[0].Title != "Karma Police" || tracks[0].Artist != "Radiohead" {
-		t.Errorf("track[0] = %+v, want {Radiohead Karma Police}", tracks[0])
-	}
-	if tracks[1].Title != "No Surprises" {
-		t.Errorf("track[1].Title = %q, want %q", tracks[1].Title, "No Surprises")
-	}
-	_ = ts // referenced to avoid unused-var warning
+	t.Cleanup(l.srv.Close)
+	return l
 }
 
-func TestFetchLastFMTracksUnsupportedType(t *testing.T) {
-	_, err := fetchLastFMTracks(context.Background(), "rj", "playlists")
-	if err == nil {
-		t.Error("expected error for unsupported list type, got nil")
+// firstPath returns the escaped path of the first request, failing the test if
+// nothing was requested at all.
+func (l *lastfmMock) firstPath(t *testing.T) string {
+	t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.paths) == 0 {
+		t.Fatal("no request reached the Last.fm mock")
+	}
+	return l.paths[0]
+}
+
+func xspfBody(t *testing.T, tracks ...xspfTrack) []byte {
+	t.Helper()
+	body, err := xml.Marshal(xspfPlaylist{Title: "Test Playlist", TrackList: tracks})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+// lastfmDownloader returns a Downloader whose Last.fm calls hit srv.
+func lastfmDownloader(t *testing.T, l *lastfmMock) *Downloader {
+	t.Helper()
+	d := testDownloader(t, Options{NoDB: true})
+	d.lastfmBase = l.srv.URL + "/user/"
+	return d
+}
+
+func TestFetchLastFMTracks(t *testing.T) {
+	body := xspfBody(t,
+		xspfTrack{Title: "Karma Police", Creator: "Radiohead"},
+		xspfTrack{Title: "No Surprises", Creator: "Radiohead"},
+		xspfTrack{Title: "", Creator: "Empty Artist"}, // skipped: no title
+		xspfTrack{Title: "No Creator", Creator: ""},   // skipped: no artist
+	)
+	l := newLastFMMock(t, http.StatusOK, body)
+	d := lastfmDownloader(t, l)
+
+	tracks, err := d.fetchLastFMTracks(context.Background(), "rj", "loved")
+	if err != nil {
+		t.Fatalf("fetchLastFMTracks: %v", err)
+	}
+	if len(tracks) != 2 {
+		t.Fatalf("got %d tracks, want 2 (incomplete entries dropped): %+v", len(tracks), tracks)
+	}
+	if tracks[0].Artist != "Radiohead" || tracks[0].Title != "Karma Police" {
+		t.Errorf("track[0] = %+v", tracks[0])
+	}
+	if want := "/user/rj/lovedtracks.xspf"; l.firstPath(t) != want {
+		t.Errorf("requested %q, want %q", l.firstPath(t), want)
+	}
+}
+
+// "library" maps to a different XSPF document than "loved".
+func TestFetchLastFMTracks_LibraryUsesRecentTracks(t *testing.T) {
+	l := newLastFMMock(t, http.StatusOK, xspfBody(t, xspfTrack{Title: "T", Creator: "A"}))
+	d := lastfmDownloader(t, l)
+
+	if _, err := d.fetchLastFMTracks(context.Background(), "rj", "library"); err != nil {
+		t.Fatalf("fetchLastFMTracks: %v", err)
+	}
+	if want := "/user/rj/recenttracks.xspf"; l.firstPath(t) != want {
+		t.Errorf("requested %q, want %q", l.firstPath(t), want)
+	}
+}
+
+// Usernames with characters that need escaping must not corrupt the path.
+func TestFetchLastFMTracks_EscapesUsername(t *testing.T) {
+	l := newLastFMMock(t, http.StatusOK, xspfBody(t))
+	d := lastfmDownloader(t, l)
+
+	if _, err := d.fetchLastFMTracks(context.Background(), "a b/c", "loved"); err != nil {
+		t.Fatalf("fetchLastFMTracks: %v", err)
+	}
+	if want := "/user/a%20b%2Fc/lovedtracks.xspf"; l.firstPath(t) != want {
+		t.Errorf("requested %q, want %q", l.firstPath(t), want)
+	}
+}
+
+func TestFetchLastFMTracks_Errors(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		body     []byte
+		listType string
+		wantMsg  string
+	}{
+		{"unknown user", http.StatusNotFound, nil, "loved", "not found"},
+		{"server error", http.StatusInternalServerError, nil, "loved", "HTTP 500"},
+		{"malformed xml", http.StatusOK, []byte("<playlist><trackList>"), "loved", "decode"},
+		{"unsupported list", http.StatusOK, nil, "playlists", "unsupported"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			l := newLastFMMock(t, c.status, c.body)
+			d := lastfmDownloader(t, l)
+
+			_, err := d.fetchLastFMTracks(context.Background(), "rj", c.listType)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), c.wantMsg) {
+				t.Errorf("error %q should mention %q", err, c.wantMsg)
+			}
+		})
+	}
+}
+
+// Full flow: XSPF from Last.fm, each track looked up on Qobuz by
+// "artist title", top hit downloaded into a playlist directory.
+func TestDownloadLastFMPlaylist_EndToEnd(t *testing.T) {
+	m := newQobuzMock(t, nil)
+	m.album = testAlbum(m.srv.URL+"/cover.jpg", track(901, 5, 1, "Karma Police"))
+
+	lfm := newLastFMMock(t, http.StatusOK,
+		xspfBody(t, xspfTrack{Title: "Karma Police", Creator: "Radiohead"}))
+
+	d, dir := m.downloaderFor(t, nil)
+	d.lastfmBase = lfm.srv.URL + "/user/"
+
+	if err := d.HandleURL(context.Background(), "https://www.last.fm/user/rj/loved"); err != nil {
+		t.Fatalf("HandleURL: %v", err)
+	}
+
+	if got := m.searchQueries(); len(got) != 1 || got[0] != "Radiohead Karma Police" {
+		t.Errorf("Qobuz search queries = %q, want [\"Radiohead Karma Police\"]", got)
+	}
+
+	path := filepath.Join(dir, "Last.fm - rj - loved tracks",
+		"Test Artist - Test Album", "05. Karma Police.flac")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("missing %s: %v", path, err)
+	}
+}
+
+// A track with no Qobuz match is reported and skipped, not fatal.
+func TestDownloadLastFMPlaylist_SkipsUnmatchedTracks(t *testing.T) {
+	m := newQobuzMock(t, nil)
+	m.album = testAlbum(m.srv.URL+"/cover.jpg", track(902, 1, 1, "Findable"))
+	m.searchMisses = map[string]bool{"Nobody Unfindable": true}
+
+	lfm := newLastFMMock(t, http.StatusOK, xspfBody(t,
+		xspfTrack{Title: "Unfindable", Creator: "Nobody"},
+		xspfTrack{Title: "Findable", Creator: "Somebody"},
+	))
+
+	d, dir := m.downloaderFor(t, nil)
+	d.lastfmBase = lfm.srv.URL + "/user/"
+
+	if err := d.HandleURL(context.Background(), "https://www.last.fm/user/rj/loved"); err != nil {
+		t.Fatalf("HandleURL: %v", err)
+	}
+
+	path := filepath.Join(dir, "Last.fm - rj - loved tracks",
+		"Test Artist - Test Album", "01. Findable.flac")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("the matched track should still be downloaded: %v", err)
 	}
 }

--- a/internal/downloader/metadata.go
+++ b/internal/downloader/metadata.go
@@ -67,24 +67,21 @@ func buildFLACTags(track, album map[string]interface{}, isTrack bool) map[string
 		t["TRACKTOTAL"] = fmt.Sprintf("%v", nestedFloat(track, "album", "tracks_count"))
 		t["ALBUM"] = nestedStr(track, "album", "title")
 		t["DATE"] = nestedStr(track, "album", "release_date_original")
-		t["COPYRIGHT"] = formatCopyright(safeGetStr(track, "copyright"))
+		t["COPYRIGHT"] = formatCopyright(nestedStr(track, "copyright"))
 		t["LABEL"] = nestedStr(track, "album", "label", "name")
 	} else {
 		if performer == "" {
 			performer = nestedStr(album, "artist", "name")
 		}
 		t["ARTIST"] = performer
-		t["GENRE"] = formatGenres(sliceStrings(album, "", "genres_list"))
+		t["GENRE"] = formatGenres(sliceStrings(album, "genres_list"))
 		t["ALBUMARTIST"] = nestedStr(album, "artist", "name")
-		t["TRACKTOTAL"] = fmt.Sprintf("%v", nestedFloat(album, "", "tracks_count"))
-		t["ALBUM"] = nestedStr(album, "", "title")
-		if t["ALBUM"] == "" {
-			t["ALBUM"], _ = album["title"].(string)
-		}
+		t["TRACKTOTAL"] = fmt.Sprintf("%v", nestedFloat(album, "tracks_count"))
+		t["ALBUM"] = nestedStr(album, "title")
 		if rd, _ := album["release_date_original"].(string); rd != "" {
 			t["DATE"] = rd
 		}
-		t["COPYRIGHT"] = formatCopyright(safeGetStr(album, "copyright"))
+		t["COPYRIGHT"] = formatCopyright(nestedStr(album, "copyright"))
 		t["LABEL"] = nestedStr(album, "label", "name")
 	}
 
@@ -286,14 +283,14 @@ func buildMP3Tags(track, album map[string]interface{}, isTrack bool) map[string]
 		t["TPE2"] = nestedStr(track, "album", "artist", "name")
 		t["TALB"] = nestedStr(track, "album", "title")
 		t["TDRC"] = nestedStr(track, "album", "release_date_original")
-		t["TCOP"] = formatCopyright(safeGetStr(track, "copyright"))
+		t["TCOP"] = formatCopyright(nestedStr(track, "copyright"))
 		t["TPUB"] = nestedStr(track, "album", "label", "name")
 		trackTotal = fmt.Sprintf("%v", nestedFloat(track, "album", "tracks_count"))
 	} else {
 		if performer == "" {
 			performer = nestedStr(album, "artist", "name")
 		}
-		t["TCON"] = formatGenres(sliceStrings(album, "", "genres_list"))
+		t["TCON"] = formatGenres(sliceStrings(album, "genres_list"))
 		t["TPE2"] = nestedStr(album, "artist", "name")
 		if v, ok := album["title"].(string); ok {
 			t["TALB"] = v
@@ -301,9 +298,9 @@ func buildMP3Tags(track, album map[string]interface{}, isTrack bool) map[string]
 		if v, ok := album["release_date_original"].(string); ok {
 			t["TDRC"] = v
 		}
-		t["TCOP"] = formatCopyright(safeGetStr(album, "copyright"))
+		t["TCOP"] = formatCopyright(nestedStr(album, "copyright"))
 		t["TPUB"] = nestedStr(album, "label", "name")
-		trackTotal = fmt.Sprintf("%v", getFloat(album, "tracks_count"))
+		trackTotal = fmt.Sprintf("%v", nestedFloat(album, "tracks_count"))
 	}
 	t["TPE1"] = performer
 	if t["TDRC"] != "" && len(t["TDRC"]) >= 4 {
@@ -486,17 +483,18 @@ func formatGenres(genres []string) string {
 	return strings.Join(unique, ", ")
 }
 
-func sliceStrings(m map[string]interface{}, subKey, key string) []string {
-	var src interface{} = m
-	if subKey != "" {
-		sub, _ := m[subKey].(map[string]interface{})
-		if sub == nil {
+// sliceStrings walks nested maps and returns the string entries of the list at
+// the end of the path, skipping anything that is not a string.
+func sliceStrings(m map[string]interface{}, keys ...string) []string {
+	var cur interface{} = m
+	for _, k := range keys {
+		mm, ok := cur.(map[string]interface{})
+		if !ok {
 			return nil
 		}
-		src = sub
+		cur = mm[k]
 	}
-	mm, _ := src.(map[string]interface{})
-	raw, _ := mm[key].([]interface{})
+	raw, _ := cur.([]interface{})
 	var result []string
 	for _, r := range raw {
 		if s, ok := r.(string); ok {
@@ -506,21 +504,18 @@ func sliceStrings(m map[string]interface{}, subKey, key string) []string {
 	return result
 }
 
-func safeGetStr(m map[string]interface{}, key string) string {
-	v, _ := m[key].(string)
-	return v
-}
-
-func nestedFloat(m map[string]interface{}, subKey, key string) float64 {
-	var src interface{} = m
-	if subKey != "" {
-		sub, _ := m[subKey].(map[string]interface{})
-		if sub == nil {
+// nestedFloat walks nested maps and returns the float64 at the end of the
+// path, or 0 if any step is missing or has the wrong type. Counterpart of
+// nestedStr.
+func nestedFloat(m map[string]interface{}, keys ...string) float64 {
+	var cur interface{} = m
+	for _, k := range keys {
+		mm, ok := cur.(map[string]interface{})
+		if !ok {
 			return 0
 		}
-		src = sub
+		cur = mm[k]
 	}
-	mm, _ := src.(map[string]interface{})
-	v, _ := mm[key].(float64)
+	v, _ := cur.(float64)
 	return v
 }

--- a/internal/downloader/metadata.go
+++ b/internal/downloader/metadata.go
@@ -11,23 +11,33 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"unicode/utf16"
 )
 
 // ---- FLAC tagging ----
 
-// tagFLAC writes Vorbis Comment metadata to a FLAC file,
-// then renames tmpFile → finalFile.
+// FLAC metadata block types (the ones we read or replace).
+const (
+	typeStreamInfo    = 0
+	typeVorbisComment = 4
+	typePicture       = 6
+)
+
+// tagFLAC writes Vorbis Comment metadata — and, when embedArt is set, the
+// cover art — to a FLAC file in a single rewrite, then renames tmpFile →
+// finalFile.
 func tagFLAC(tmpFile, coverDir, finalFile string, track, album map[string]interface{}, isTrack, embedArt bool) error {
-	tags := buildFLACTags(track, album, isTrack)
-	if err := writeFLACTags(tmpFile, tags); err != nil {
-		return err
-	}
+	var cover []byte
 	if embedArt {
-		if err := embedFLACCover(tmpFile, coverDir); err != nil {
+		var err error
+		if cover, err = readCover(coverDir); err != nil {
 			fmt.Printf("\033[33mWarning: could not embed cover: %v\033[0m\n", err)
 		}
+	}
+	if err := writeFLACMeta(tmpFile, buildFLACTags(track, album, isTrack), cover); err != nil {
+		return err
 	}
 	return os.Rename(tmpFile, finalFile)
 }
@@ -81,36 +91,57 @@ func buildFLACTags(track, album map[string]interface{}, isTrack bool) map[string
 	return t
 }
 
-// writeFLACTags reads a FLAC file, replaces/adds a VORBIS_COMMENT block, and writes back.
-// FLAC format: 4-byte magic, then a sequence of metadata blocks.
-// Each block: 1-byte type+last_flag, 3-byte length, then data.
-func writeFLACTags(path string, tags map[string]string) error {
-	data, err := os.ReadFile(path)
+// flacBlock is a single FLAC metadata block. The last-block flag is not stored
+// — writeFLAC recomputes it from the position in the slice.
+type flacBlock struct {
+	blockType byte
+	data      []byte
+}
+
+// writeFLACMeta rewrites the metadata of a FLAC file in one pass: the
+// VORBIS_COMMENT block is replaced with tags, and when cover is non-nil the
+// existing PICTURE blocks are replaced with it. A nil cover leaves whatever
+// artwork the file already carries untouched.
+func writeFLACMeta(path string, tags map[string]string, cover []byte) error {
+	drop := []byte{typeVorbisComment}
+	if cover != nil {
+		drop = append(drop, typePicture)
+	}
+	blocks, audio, err := splitFLAC(path, drop...)
 	if err != nil {
 		return err
 	}
+
+	// Vorbis Comment belongs right after STREAMINFO; without one, it goes last.
+	vc := flacBlock{typeVorbisComment, buildVorbisComment(tags)}
+	if i := slices.IndexFunc(blocks, func(b flacBlock) bool { return b.blockType == typeStreamInfo }); i >= 0 {
+		blocks = slices.Insert(blocks, i+1, vc)
+	} else {
+		blocks = append(blocks, vc)
+	}
+
+	if cover != nil {
+		blocks = append(blocks, flacBlock{typePicture, buildFLACPictureBlock(cover)})
+	}
+	return writeFLAC(path, blocks, audio)
+}
+
+// splitFLAC parses a FLAC file into its metadata blocks and the audio data
+// that follows, discarding every block whose type appears in drop.
+// FLAC format: 4-byte magic, then a sequence of metadata blocks.
+// Each block: 1-byte type+last_flag, 3-byte length, then data.
+func splitFLAC(path string, drop ...byte) ([]flacBlock, []byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
 	if len(data) < 4 || string(data[:4]) != "fLaC" {
-		return fmt.Errorf("not a FLAC file: %s", path)
+		return nil, nil, fmt.Errorf("not a FLAC file: %s", path)
 	}
 
-	// Parse existing blocks, removing any existing VORBIS_COMMENT (type 4)
-	const (
-		typeStreamInfo    = 0
-		typeVorbisComment = 4
-		typePicture       = 6
-	)
-
-	type block struct {
-		blockType byte
-		data      []byte
-	}
-
-	var blocks []block
+	var blocks []flacBlock
 	pos := 4
-	for pos < len(data) {
-		if pos+4 > len(data) {
-			break
-		}
+	for pos+4 <= len(data) {
 		header := data[pos]
 		isLast := (header & 0x80) != 0
 		bType := header & 0x7F
@@ -119,42 +150,24 @@ func writeFLACTags(path string, tags map[string]string) error {
 		if pos+length > len(data) {
 			break
 		}
-		blockData := data[pos : pos+length]
-		pos += length
-
-		if bType != typeVorbisComment {
-			blocks = append(blocks, block{bType, blockData})
+		if !slices.Contains(drop, bType) {
+			blocks = append(blocks, flacBlock{bType, data[pos : pos+length]})
 		}
+		pos += length
 		if isLast {
 			break
 		}
 	}
-	audioData := data[pos:]
+	return blocks, data[pos:], nil
+}
 
-	// Build new Vorbis Comment block
-	vcData := buildVorbisComment(tags)
-
-	// Re-assemble: insert VC block after STREAMINFO
-	var newBlocks []block
-	inserted := false
-	for _, b := range blocks {
-		newBlocks = append(newBlocks, b)
-		if b.blockType == typeStreamInfo && !inserted {
-			newBlocks = append(newBlocks, block{typeVorbisComment, vcData})
-			inserted = true
-		}
-	}
-	if !inserted {
-		newBlocks = append(newBlocks, block{typeVorbisComment, vcData})
-	}
-
-	// Encode blocks
-	var out []byte
-	out = append(out, 'f', 'L', 'a', 'C')
-	for i, b := range newBlocks {
-		isLast := i == len(newBlocks)-1
+// writeFLAC encodes blocks followed by audio back to path, flagging the last
+// metadata block as required by the format.
+func writeFLAC(path string, blocks []flacBlock, audio []byte) error {
+	out := []byte("fLaC")
+	for i, b := range blocks {
 		header := b.blockType
-		if isLast {
+		if i == len(blocks)-1 {
 			header |= 0x80
 		}
 		length := len(b.data)
@@ -162,8 +175,7 @@ func writeFLACTags(path string, tags map[string]string) error {
 			byte(length>>16), byte(length>>8), byte(length))
 		out = append(out, b.data...)
 	}
-	out = append(out, audioData...)
-
+	out = append(out, audio...)
 	return os.WriteFile(path, out, 0644)
 }
 
@@ -201,73 +213,6 @@ func appendU32LE(b []byte, v uint32) []byte {
 	return append(b, byte(v), byte(v>>8), byte(v>>16), byte(v>>24))
 }
 
-func embedFLACCover(flacPath, coverDir string) error {
-	coverPath := findCover(coverDir)
-	if coverPath == "" {
-		return fmt.Errorf("cover not found")
-	}
-	imgData, err := os.ReadFile(coverPath)
-	if err != nil {
-		return err
-	}
-
-	const typePicture = 6
-	picBlock := buildFLACPictureBlock(imgData)
-	data, err := os.ReadFile(flacPath)
-	if err != nil {
-		return err
-	}
-	if len(data) < 4 {
-		return fmt.Errorf("bad FLAC")
-	}
-
-	type block struct {
-		blockType byte
-		data      []byte
-	}
-	var blocks []block
-	pos := 4
-	for pos < len(data) {
-		if pos+4 > len(data) {
-			break
-		}
-		header := data[pos]
-		isLast := (header & 0x80) != 0
-		bType := header & 0x7F
-		length := int(data[pos+1])<<16 | int(data[pos+2])<<8 | int(data[pos+3])
-		pos += 4
-		if pos+length > len(data) {
-			break
-		}
-		blockData := data[pos : pos+length]
-		pos += length
-		if bType != typePicture { // remove old pictures
-			blocks = append(blocks, block{bType, blockData})
-		}
-		if isLast {
-			break
-		}
-	}
-	audioData := data[pos:]
-
-	blocks = append(blocks, block{typePicture, picBlock})
-
-	var out []byte
-	out = append(out, 'f', 'L', 'a', 'C')
-	for i, b := range blocks {
-		isLast := i == len(blocks)-1
-		header := b.blockType
-		if isLast {
-			header |= 0x80
-		}
-		length := len(b.data)
-		out = append(out, header, byte(length>>16), byte(length>>8), byte(length))
-		out = append(out, b.data...)
-	}
-	out = append(out, audioData...)
-	return os.WriteFile(flacPath, out, 0644)
-}
-
 func buildFLACPictureBlock(imgData []byte) []byte {
 	mimeType := "image/jpeg"
 	desc := ""
@@ -291,6 +236,15 @@ func buildFLACPictureBlock(imgData []byte) []byte {
 
 func appendU32BE(b []byte, v uint32) []byte {
 	return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+}
+
+// readCover loads the cover image next to (or one level above) dir.
+func readCover(dir string) ([]byte, error) {
+	path := findCover(dir)
+	if path == "" {
+		return nil, fmt.Errorf("cover not found")
+	}
+	return os.ReadFile(path)
 }
 
 func findCover(dir string) string {
@@ -381,12 +335,8 @@ func writeID3v23(path string, tags map[string]string, embedArt bool, coverDir st
 	}
 
 	if embedArt {
-		coverPath := findCover(coverDir)
-		if coverPath != "" {
-			if imgData, err := os.ReadFile(coverPath); err == nil {
-				frame := buildAPICFrame(imgData)
-				frames = append(frames, frame...)
-			}
+		if imgData, err := readCover(coverDir); err == nil {
+			frames = append(frames, buildAPICFrame(imgData)...)
 		}
 	}
 

--- a/internal/downloader/metadata.go
+++ b/internal/downloader/metadata.go
@@ -7,6 +7,7 @@ package downloader
 // Both are pure-Go implementations with no external dependencies.
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
@@ -196,18 +197,14 @@ func buildVorbisComment(tags map[string]string) []byte {
 		size += 4 + len(c)
 	}
 	buf := make([]byte, 0, size)
-	buf = appendU32LE(buf, uint32(len(vendorBytes)))
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(vendorBytes)))
 	buf = append(buf, vendorBytes...)
-	buf = appendU32LE(buf, uint32(len(comments)))
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(comments)))
 	for _, c := range comments {
-		buf = appendU32LE(buf, uint32(len(c)))
+		buf = binary.LittleEndian.AppendUint32(buf, uint32(len(c)))
 		buf = append(buf, c...)
 	}
 	return buf
-}
-
-func appendU32LE(b []byte, v uint32) []byte {
-	return append(b, byte(v), byte(v>>8), byte(v>>16), byte(v>>24))
 }
 
 func buildFLACPictureBlock(imgData []byte) []byte {
@@ -217,22 +214,18 @@ func buildFLACPictureBlock(imgData []byte) []byte {
 	// picture_type, mime_length, mime, desc_length, desc,
 	// width, height, color_depth, color_count, data_length, data
 	buf := make([]byte, 0, 32+len(mimeType)+len(imgData))
-	buf = appendU32BE(buf, 3) // Front cover
-	buf = appendU32BE(buf, uint32(len(mimeType)))
+	buf = binary.BigEndian.AppendUint32(buf, 3) // Front cover
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(mimeType)))
 	buf = append(buf, []byte(mimeType)...)
-	buf = appendU32BE(buf, uint32(len(desc)))
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(desc)))
 	buf = append(buf, []byte(desc)...)
-	buf = appendU32BE(buf, 0) // width (unknown)
-	buf = appendU32BE(buf, 0) // height
-	buf = appendU32BE(buf, 0) // color depth
-	buf = appendU32BE(buf, 0) // color count
-	buf = appendU32BE(buf, uint32(len(imgData)))
+	buf = binary.BigEndian.AppendUint32(buf, 0) // width (unknown)
+	buf = binary.BigEndian.AppendUint32(buf, 0) // height
+	buf = binary.BigEndian.AppendUint32(buf, 0) // color depth
+	buf = binary.BigEndian.AppendUint32(buf, 0) // color count
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(imgData)))
 	buf = append(buf, imgData...)
 	return buf
-}
-
-func appendU32BE(b []byte, v uint32) []byte {
-	return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
 }
 
 // readCover loads the cover image next to (or one level above) dir.

--- a/internal/downloader/metadata_test.go
+++ b/internal/downloader/metadata_test.go
@@ -1,6 +1,7 @@
 package downloader
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,8 +25,8 @@ func TestWriteFLACTags_RoundTrip(t *testing.T) {
 		"TRACKNUMBER": "3",
 		"DATE":        "2024-04-01",
 	}
-	if err := writeFLACTags(tmp, tags); err != nil {
-		t.Fatalf("writeFLACTags: %v", err)
+	if err := writeFLACMeta(tmp, tags, nil); err != nil {
+		t.Fatalf("writeFLACMeta: %v", err)
 	}
 
 	// Read back and verify the Vorbis Comment block is present
@@ -70,10 +71,85 @@ func TestWriteFLACTags_RoundTrip(t *testing.T) {
 	}
 }
 
+// Tags and cover art are written in a single rewrite: the Vorbis Comment must
+// land right after STREAMINFO, the stale PICTURE block must be replaced (not
+// duplicated), and the audio data must survive untouched.
+func TestWriteFLACMeta_TagsAndCoverInOnePass(t *testing.T) {
+	flac := append([]byte("fLaC"), 0x00, 0x00, 0x00, 0x22) // STREAMINFO, not last, len 34
+	flac = append(flac, make([]byte, 34)...)
+	flac = append(flac, 0x86, 0x00, 0x00, 0x03) // PICTURE, last, len 3
+	flac = append(flac, "old"...)
+	audio := []byte{0xff, 0xf8, 0x00, 0x00}
+	flac = append(flac, audio...)
+
+	tmp := tempFile(t, "*.flac")
+	if err := os.WriteFile(tmp, flac, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cover := []byte("JPEGDATA")
+	if err := writeFLACMeta(tmp, map[string]string{"TITLE": "One Pass"}, cover); err != nil {
+		t.Fatalf("writeFLACMeta: %v", err)
+	}
+
+	out, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocks, tail := walkFLAC(t, out)
+
+	var types []byte
+	for _, b := range blocks {
+		types = append(types, b.blockType)
+	}
+	if want := []byte{typeStreamInfo, typeVorbisComment, typePicture}; !bytes.Equal(types, want) {
+		t.Fatalf("block types = %v, want %v", types, want)
+	}
+	if !strings.Contains(string(blocks[1].data), "TITLE=One Pass") {
+		t.Error("TITLE tag missing from Vorbis Comment block")
+	}
+	if !bytes.HasSuffix(blocks[2].data, cover) {
+		t.Error("new cover not found in PICTURE block")
+	}
+	if bytes.Contains(blocks[2].data, []byte("old")) {
+		t.Error("stale PICTURE block was not replaced")
+	}
+	if !bytes.Equal(tail, audio) {
+		t.Errorf("audio data = %q, want %q", tail, audio)
+	}
+}
+
+// walkFLAC parses an encoded FLAC into its metadata blocks and trailing audio,
+// failing the test unless exactly the final block carries the last-block flag.
+func walkFLAC(t *testing.T, data []byte) ([]flacBlock, []byte) {
+	t.Helper()
+	if len(data) < 4 || string(data[:4]) != "fLaC" {
+		t.Fatal("output is not a FLAC file")
+	}
+	var blocks []flacBlock
+	pos := 4
+	for pos+4 <= len(data) {
+		isLast := data[pos]&0x80 != 0
+		bType := data[pos] & 0x7F
+		n := int(data[pos+1])<<16 | int(data[pos+2])<<8 | int(data[pos+3])
+		pos += 4
+		if pos+n > len(data) {
+			t.Fatalf("block %d overruns end of file", len(blocks))
+		}
+		blocks = append(blocks, flacBlock{bType, data[pos : pos+n]})
+		pos += n
+		if isLast {
+			return blocks, data[pos:]
+		}
+	}
+	t.Fatal("no block carries the last-block flag")
+	return nil, nil
+}
+
 func TestWriteFLACTags_NotFLAC(t *testing.T) {
 	tmp := tempFile(t, "*.flac")
 	os.WriteFile(tmp, []byte("not a flac file"), 0644)
-	err := writeFLACTags(tmp, map[string]string{"TITLE": "x"})
+	err := writeFLACMeta(tmp, map[string]string{"TITLE": "x"}, nil)
 	if err == nil {
 		t.Error("expected error for non-FLAC file")
 	}

--- a/internal/downloader/metadata_test.go
+++ b/internal/downloader/metadata_test.go
@@ -278,6 +278,42 @@ func TestBuildFLACTags_IsTrack(t *testing.T) {
 	check("COPYRIGHT", "\u2117 2024")
 }
 
+// The album branch reads its fields straight off the album map rather than
+// through an "album" sub-key, which is what distinguishes it from IsTrack.
+func TestBuildFLACTags_FromAlbum(t *testing.T) {
+	track := map[string]interface{}{
+		"title":        "My Song",
+		"track_number": float64(2),
+	}
+	album := map[string]interface{}{
+		"title":                 "My Album",
+		"artist":                map[string]interface{}{"name": "Album Artist"},
+		"release_date_original": "2024-01-15",
+		"tracks_count":          float64(9),
+		"genres_list":           []interface{}{"Pop/Rock", "Pop/Rock→Rock"},
+		"label":                 map[string]interface{}{"name": "Best Label"},
+		"copyright":             "(C) 2024",
+	}
+	tags := buildFLACTags(track, album, false)
+
+	check := func(key, want string) {
+		t.Helper()
+		if got := tags[key]; got != want {
+			t.Errorf("tag %s = %q, want %q", key, got, want)
+		}
+	}
+	check("TITLE", "My Song")
+	check("TRACKNUMBER", "2")
+	check("ARTIST", "Album Artist")
+	check("ALBUMARTIST", "Album Artist")
+	check("ALBUM", "My Album")
+	check("DATE", "2024-01-15")
+	check("TRACKTOTAL", "9")
+	check("GENRE", "Pop, Rock")
+	check("LABEL", "Best Label")
+	check("COPYRIGHT", "© 2024")
+}
+
 func TestBuildFLACTags_WithVersion(t *testing.T) {
 	track := map[string]interface{}{
 		"title":   "Track",

--- a/internal/lyrics/metadata.go
+++ b/internal/lyrics/metadata.go
@@ -248,8 +248,19 @@ func decodeID3Text(data []byte) string {
 		return strings.TrimRight(string(payload), "\x00")
 
 	default: // 0x00 Latin-1
-		return strings.TrimRight(string(payload), "\x00")
+		return strings.TrimRight(decodeLatin1(payload), "\x00")
 	}
+}
+
+// decodeLatin1 decodes ISO-8859-1, where every byte maps onto the code point
+// of the same value. Converting the bytes directly with string() would instead
+// read them as UTF-8 and turn every accented character into U+FFFD.
+func decodeLatin1(b []byte) string {
+	runes := make([]rune, len(b))
+	for i, c := range b {
+		runes[i] = rune(c)
+	}
+	return string(runes)
 }
 
 // decodeUTF16 decodes b as UTF-16 code units in the given byte order, after

--- a/internal/lyrics/metadata.go
+++ b/internal/lyrics/metadata.go
@@ -224,57 +224,46 @@ func decodeID3Text(data []byte) string {
 	if len(data) == 0 {
 		return ""
 	}
-	enc := data[0]
 	payload := data[1:]
 
-	stripNulUTF8 := func(s string) string { return strings.TrimRight(s, "\x00") }
-
-	switch enc {
-	case 0x01: // UTF-16 with BOM
+	switch data[0] {
+	case 0x01: // UTF-16 with BOM — absent BOM means little-endian
 		if len(payload) < 2 {
 			return ""
 		}
-		bigEndian := payload[0] == 0xFE && payload[1] == 0xFF
-		// advance past BOM if present (FF FE or FE FF)
-		if (payload[0] == 0xFF && payload[1] == 0xFE) || bigEndian {
+		order := binary.ByteOrder(binary.LittleEndian)
+		switch {
+		case payload[0] == 0xFE && payload[1] == 0xFF:
+			order = binary.BigEndian
+			payload = payload[2:]
+		case payload[0] == 0xFF && payload[1] == 0xFE:
 			payload = payload[2:]
 		}
-		// strip trailing UTF-16 null terminator
-		for len(payload) >= 2 && payload[len(payload)-2] == 0 && payload[len(payload)-1] == 0 {
-			payload = payload[:len(payload)-2]
-		}
-		if len(payload)%2 != 0 && len(payload) > 0 {
-			payload = payload[:len(payload)-1]
-		}
-		u16 := make([]uint16, len(payload)/2)
-		for i := range u16 {
-			if bigEndian {
-				u16[i] = uint16(payload[2*i])<<8 | uint16(payload[2*i+1])
-			} else {
-				u16[i] = uint16(payload[2*i]) | uint16(payload[2*i+1])<<8
-			}
-		}
-		return string(utf16.Decode(u16))
+		return decodeUTF16(payload, order)
 
 	case 0x02: // UTF-16BE without BOM
-		for len(payload) >= 2 && payload[len(payload)-2] == 0 && payload[len(payload)-1] == 0 {
-			payload = payload[:len(payload)-2]
-		}
-		if len(payload)%2 != 0 && len(payload) > 0 {
-			payload = payload[:len(payload)-1]
-		}
-		u16 := make([]uint16, len(payload)/2)
-		for i := range u16 {
-			u16[i] = uint16(payload[2*i])<<8 | uint16(payload[2*i+1])
-		}
-		return string(utf16.Decode(u16))
+		return decodeUTF16(payload, binary.BigEndian)
 
 	case 0x03: // UTF-8
-		return stripNulUTF8(string(payload))
+		return strings.TrimRight(string(payload), "\x00")
 
 	default: // 0x00 Latin-1
-		return stripNulUTF8(string(payload))
+		return strings.TrimRight(string(payload), "\x00")
 	}
+}
+
+// decodeUTF16 decodes b as UTF-16 code units in the given byte order, after
+// dropping any trailing null terminators and a stray odd byte.
+func decodeUTF16(b []byte, order binary.ByteOrder) string {
+	for len(b) >= 2 && b[len(b)-2] == 0 && b[len(b)-1] == 0 {
+		b = b[:len(b)-2]
+	}
+	b = b[:len(b)-len(b)%2]
+	u16 := make([]uint16, len(b)/2)
+	for i := range u16 {
+		u16[i] = order.Uint16(b[2*i:])
+	}
+	return string(utf16.Decode(u16))
 }
 
 // ---- MPEG duration helpers ----------------------------------------------

--- a/internal/lyrics/metadata_test.go
+++ b/internal/lyrics/metadata_test.go
@@ -1,6 +1,7 @@
 package lyrics
 
 import (
+	"bytes"
 	"encoding/binary"
 	"os"
 	"testing"
@@ -97,9 +98,14 @@ func id3Syncsafe(n int) [4]byte {
 	return b
 }
 
-// id3FrameLatin1 builds an ID3v2.3 text frame with Latin-1 encoding.
+// id3FrameLatin1 builds an ID3v2.3 text frame with Latin-1 encoding: one byte
+// per rune. Callers must stay within U+0000–U+00FF; []byte(text) would emit
+// UTF-8 instead and no longer be a Latin-1 frame.
 func id3FrameLatin1(id, text string) []byte {
-	payload := append([]byte{0x00}, []byte(text)...)
+	payload := []byte{0x00}
+	for _, r := range text {
+		payload = append(payload, byte(r))
+	}
 	payload = append(payload, 0x00)
 	size := len(payload)
 	hdr := []byte{id[0], id[1], id[2], id[3],
@@ -235,6 +241,41 @@ func TestReadMP3_Latin1Tags(t *testing.T) {
 	}
 }
 
+// Round trip through a real Latin-1 tag: accented characters live in the
+// 0x80–0xFF range, which is invalid UTF-8. Reading those bytes with string()
+// yields U+FFFD, and the mangled artist then produces an LRCLIB miss.
+func TestReadMP3_Latin1Accents(t *testing.T) {
+	frames := id3FrameLatin1("TIT2", "Cañón")
+	frames = append(frames, id3FrameLatin1("TPE1", "Björk")...)
+	frames = append(frames, id3FrameLatin1("TALB", "Café Müller")...)
+
+	path := writeTmp(t, ".mp3", fakeMP3(frames))
+
+	// Guard the fixture itself: ö must be the single byte 0xF6 on disk, not
+	// the UTF-8 pair C3 B6, or the test would not be exercising Latin-1.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(raw, []byte{'B', 'j', 0xF6, 'r', 'k'}) {
+		t.Fatal("fixture is not Latin-1 encoded")
+	}
+
+	info, err := ReadAudio(path)
+	if err != nil {
+		t.Fatalf("ReadAudio: %v", err)
+	}
+	if info.Title != "Cañón" {
+		t.Errorf("Title = %q, want %q", info.Title, "Cañón")
+	}
+	if info.Artist != "Björk" {
+		t.Errorf("Artist = %q, want %q", info.Artist, "Björk")
+	}
+	if info.Album != "Café Müller" {
+		t.Errorf("Album = %q, want %q", info.Album, "Café Müller")
+	}
+}
+
 func TestReadMP3_UTF16LEFrames(t *testing.T) {
 	// qobuz-dl tags all text frames with UTF-16LE + BOM.
 	frames := id3FrameUTF16LE("TIT2", "UTF-16 Song")
@@ -300,6 +341,7 @@ func TestDecodeID3Text(t *testing.T) {
 		want string
 	}{
 		{"latin1", []byte{0x00, 'H', 'e', 'l', 'l', 'o', 0x00}, "Hello"},
+		{"latin1 high bytes", []byte{0x00, 'B', 'j', 0xF6, 'r', 'k', 0x00}, "Björk"},
 		{"utf16 LE with BOM", []byte{0x01, 0xFF, 0xFE, 'H', 0x00, 'i', 0x00, 0x00, 0x00}, "Hi"},
 		{"utf16 BE with BOM", []byte{0x01, 0xFE, 0xFF, 0x00, 'H', 0x00, 'i', 0x00, 0x00}, "Hi"},
 		{"utf16 without BOM falls back to LE", []byte{0x01, 'H', 0x00, 'i', 0x00}, "Hi"},

--- a/internal/lyrics/metadata_test.go
+++ b/internal/lyrics/metadata_test.go
@@ -293,40 +293,28 @@ func TestReadMP3_NoID3Tag(t *testing.T) {
 
 // ---- decodeID3Text unit tests -------------------------------------------
 
-func TestDecodeID3Text_Latin1(t *testing.T) {
-	data := []byte{0x00, 'H', 'e', 'l', 'l', 'o', 0x00}
-	if got := decodeID3Text(data); got != "Hello" {
-		t.Errorf("got %q", got)
+func TestDecodeID3Text(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{"latin1", []byte{0x00, 'H', 'e', 'l', 'l', 'o', 0x00}, "Hello"},
+		{"utf16 LE with BOM", []byte{0x01, 0xFF, 0xFE, 'H', 0x00, 'i', 0x00, 0x00, 0x00}, "Hi"},
+		{"utf16 BE with BOM", []byte{0x01, 0xFE, 0xFF, 0x00, 'H', 0x00, 'i', 0x00, 0x00}, "Hi"},
+		{"utf16 without BOM falls back to LE", []byte{0x01, 'H', 0x00, 'i', 0x00}, "Hi"},
+		{"utf16BE encoding byte, no BOM", []byte{0x02, 0x00, 'H', 0x00, 'i', 0x00, 0x00}, "Hi"},
+		{"utf8", []byte{0x03, 'H', 'e', 'l', 'l', 'o', 0x00}, "Hello"},
+		{"truncated BOM", []byte{0x01, 0xFF}, ""},
+		{"nil", nil, ""},
+		{"empty", []byte{}, ""},
 	}
-}
-
-func TestDecodeID3Text_UTF16LE(t *testing.T) {
-	data := []byte{0x01, 0xFF, 0xFE, 'H', 0x00, 'i', 0x00, 0x00, 0x00}
-	if got := decodeID3Text(data); got != "Hi" {
-		t.Errorf("got %q", got)
-	}
-}
-
-func TestDecodeID3Text_UTF16BE(t *testing.T) {
-	data := []byte{0x01, 0xFE, 0xFF, 0x00, 'H', 0x00, 'i', 0x00, 0x00}
-	if got := decodeID3Text(data); got != "Hi" {
-		t.Errorf("got %q", got)
-	}
-}
-
-func TestDecodeID3Text_UTF8(t *testing.T) {
-	data := []byte{0x03, 'H', 'e', 'l', 'l', 'o', 0x00}
-	if got := decodeID3Text(data); got != "Hello" {
-		t.Errorf("got %q", got)
-	}
-}
-
-func TestDecodeID3Text_EmptyInput(t *testing.T) {
-	if got := decodeID3Text(nil); got != "" {
-		t.Errorf("nil input: got %q", got)
-	}
-	if got := decodeID3Text([]byte{}); got != "" {
-		t.Errorf("empty input: got %q", got)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := decodeID3Text(c.in); got != c.want {
+				t.Errorf("decodeID3Text(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Auditoría de sobreingeniería sobre todo el repo, aplicada en seis tandas, más los tests de integración que faltaban en `downloader`.

## Resumen

| | |
|---|---|
| Producción | −312 líneas |
| Tests | 135 → 166 |
| Cobertura `downloader` | 22.7% → 60.3% |
| Dependencias | sin cambios (5 transitivas de `mpb`, 1 directa) |
| Duración de la suite | 0.6 s, limpia con `-race` |

## Refactors

Los cuatro primeros commits eliminan duplicación estructural, no estilo:

- **Bloques FLAC** — `writeFLACTags` y `embedFLACCover` compartían 55 líneas idénticas de parseo y reensamblado. Se descomponen en `splitFLAC` / `writeFLAC`. Efecto secundario: con `--embed-art`, un FLAC pasa de leerse y escribirse entero cuatro veces por pista a dos.
- **Paginación** — tres copias del bucle que aplana `pages[*][key].items` → `collectPageItems`. `downloadArtist` y `downloadLabelOrArtist` eran la misma función salvo el filtro smart-discog → `downloadAlbumCollection`.
- **`ResolveDir`** — `resolveScanDir` era `config.ResolveDir` sin `MkdirAll`; se fusionan con un flag `create`.
- **Accesores de mapas** — de cuatro solapados (`nestedStr`, `safeGetStr`, `getFloat`, `nestedFloat`) a dos variádicos.
- **UTF-16 en ID3** — las ramas `0x01` y `0x02` de `decodeID3Text` eran el mismo bucle salvo el orden de bytes.

El resto son borrados: `GetFavoriteAlbums`, `NonStreamableError`, `Config.DefaultFolder`, `Config.DefaultLimit`, las claves legacy `email`/`password`, la rama `"extra"` de `isAlbumType`, `searchByType`, un mapa de calidades duplicado y una rama no-op en `printQueue`.

**Compatibilidad**: `writeINI` escribe primero las claves de su lista ordenada y luego el resto, así que un `config.ini` existente con las claves retiradas sigue cargando y las conserva al reescribirse. Cubierto por `TestWriteINI_StableKeyOrder` y `TestSaveToken`.

## Bugs encontrados por el camino

1. **Latin-1 en tags ID3** (`355af18`) — `decodeID3Text` decodificaba la codificación `0x00` con `string(payload)`, que asume UTF-8. Los bytes `0x80–0xFF` no son UTF-8 válido, así que cada carácter acentuado se convertía en U+FFFD: "Björk" se leía "Bj�rk" y la consulta a LRCLIB fallaba sin letra que mostrar. Afecta a bibliotecas etiquetadas por otras herramientas; los MP3 que escribe este proyecto usan UTF-16LE y nunca pasaron por la rama rota.
2. **`nestedStr(album, "", "title")`** — buscaba `album[""]` y devolvía siempre `""`. El fallback de las tres líneas siguientes era lo único que asignaba `ALBUM`. Mismo resultado, pero la llamada estaba muerta.
3. **Tres tests fósiles** que no probaban nada: `TestDoGet_401_ReturnsAuthError` hacía un GET manual y terminaba en `_ = c`; `TestFetchLastFMTracks` levantaba un servidor, no lo llamaba y reimplementaba el parseo inline; `mockServer` estaba declarado y muerto. Los tres nacieron de esquivar constantes no inyectables.

## Tests de integración

`internal/downloader/integration_test.go`, solo stdlib, dos mocks `httptest`:

- **`flakyCDN`** — corta la conexión a mitad del cuerpo, ignora `Range` respondiendo 200 con el cuerpo entero, o devuelve 4xx. Recorre las ramas de `downloadWithProgress`: resume por `Range`, descarte del parcial cuando el servidor ignora el `Range`, agotar los 5 intentos, no reintentar un 404, cancelación por contexto.
- **`qobuzMock`** — API y CDN en un servidor. El audio servido es un FLAC (o MP3) mínimo válido, así que el tagging de producción se ejecuta y se verifica leyendo los tags del fichero final. No es un mock del tagger: es la cadena entera.

Cubre álbum completo, multi-disco, skips (DB, no streamable, fichero existente), pista suelta, artista, playlist con M3U, last.fm y el tagging MP3 con carátula incrustada.

Cada bloque de tests se validó por mutación —romper la lógica a mano y comprobar que la suite lo detecta— en nueve puntos: resume sin append, `Range` ignorado, consulta a la DB, `streamable=false`, carátula no incrustada, `TRCK` sin total, `findCover` sin fallback al padre, mapeo `loved`/`library` y búsqueda devolviendo id vacío.

## Seams de test

Para hacer testeable lo anterior hicieron falta cuatro campos inyectables, siguiendo el patrón que `lyrics.Client` ya usaba y que CLAUDE.md documentaba: `api.Client.BaseURL`, `Downloader.retryDelay`, `Downloader.progressOut` y `Downloader.lastfmBase`. Todos con su valor de producción en el constructor. Sin ellos, un test de reintentos tardaría 15 s en el backoff y las barras `mpb` llenarían el log de ANSI.

## Sin cubrir

`csvbatch.go`, `interactive.go` y `oauth.go` siguen a 0%: necesitan simular stdin o un navegador. `csvbatch` es el más abordable — `ParseCSV` solo lee un fichero y `DownloadCSV` encaja con el mock que ya existe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
