### PR TITLE
refactor: cerrar la auditoría de sobreingeniería + dos fugas del TUI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ cmd/qobuz-dl/        CLI entry point (flag stdlib, sin dependencias externas)
   flags.go           wiring CLI→downloader: cliFlags, registerDownloadFlags,
                      loadOrInitConfig, initDownloader
   oauth_cmd.go       runOAuth
-  lyrics_cmd.go      runLyrics, resolveScanDir
+  lyrics_cmd.go      runLyrics
 internal/api/        Cliente HTTP Qobuz API (qopy.py)
 internal/bundle/     Scraper de app_id/secrets/private_key de bundle.js
 internal/config/     Lector/escritor de config.ini (INI casero, sin deps)
@@ -155,16 +155,16 @@ No añadir dependencias nuevas sin discusión. En particular no añadir librerí
 
 ### Cobertura por paquete
 
-Medido con `go test -cover ./...` el 2026-08-04:
+Medido con `go test -cover ./...` el 2026-08-06:
 
 | Paquete | Cobertura | Archivos de test |
 |---|---|---|
-| api | 42.3% | client_test.go |
+| api | 42.9% | client_test.go |
 | bundle | 59.7% | bundle_test.go |
-| config | 37.9% | config_test.go |
-| downloader | 41.5% | integration_test.go, oauth_test.go, tui_test.go, metadata_test.go, db_test.go, lastfm_test.go, helpers_test.go, redownload_test.go |
+| config | 45.1% | config_test.go |
+| downloader | 45.1% | integration_test.go, oauth_test.go, tui_test.go, metadata_test.go, db_test.go, lastfm_test.go, helpers_test.go, redownload_test.go |
 | lyrics | 75.6% | metadata_test.go, lrclib_test.go, lyrics_test.go |
-| ui | 53.3% | shell_test.go, handle_test.go, lang_test.go |
+| ui | 54.7% | shell_test.go, handle_test.go, lang_test.go |
 | cmd/qobuz-dl | 0% | main_test.go |
 
 `cmd/qobuz-dl` marca 0% porque sus tests son **black-box**: compilan el binario en `TestMain` y lo ejecutan como subproceso, así que la cobertura no se instrumenta. No es falta de tests.
@@ -176,7 +176,7 @@ invariante de la que depende el diseño — un `p.Send()` por `Read` satura el b
 Filtra los mensajes propios de bubbletea (window size) porque si no los conteos no significan nada.
 Validado con 6 mutaciones, todas detectadas.
 
-`helpers_test.go` en downloader cubre: `sanitize`, `expandPlaceholders`, `renderFormat`, `formatDuration`, `idStr`, `nestedStr`, `releaseYear`, `essenceTitle`, `isAlbumType`.
+`helpers_test.go` en downloader cubre: `sanitize`, `expandPlaceholders`, `renderFormat`, `formatDuration`, `idStr`, `nestedStr`, `releaseYear`, `essenceTitle`, `isRemaster`.
 
 ### Tests de integración del downloader (`integration_test.go`)
 
@@ -309,12 +309,11 @@ Jerarquía de prioridad al resolver la ruta de descarga:
 3. Fallback: `./qobuz-downloader` (relativo al CWD)
 
 Implementación:
-- `config.ResolveDir(dir string) (string, error)` — expande `~`, llama `filepath.Abs`, crea con `os.MkdirAll`; devuelve error descriptivo si hay problema de permisos (sin panic)
-- `Config.DownloadDir` — campo separado de `DefaultFolder` (que es el formato de nombre de álbum, no una ruta)
-- `Reset()` pregunta al usuario por el directorio antes de `default_folder`
+- `config.ResolveDir(dir string, create bool) (string, error)` — expande `~`, llama `filepath.Abs`; con `create` crea el árbol con `os.MkdirAll`, sin él exige que el directorio ya exista. Devuelve error descriptivo si hay problema de permisos (sin panic)
+- `Config.DownloadDir` — no confundir con la **constante** `config.DefaultFolder`, que es el formato de nombre de álbum (el default de `folder_format`), no una ruta. El campo `Config.DefaultFolder` se retiró: nadie lo leía.
 - `downloader.New()` ya no tiene fallback hardcodeado — la ruta llega siempre resuelta desde `initDownloader`
 
-**Importante**: el comando `lyrics` usa `resolveScanDir` (en `lyrics_cmd.go`), que es igual a `ResolveDir` pero **sin** `os.MkdirAll` — no crea el directorio si no existe. El usuario debe apuntar a una biblioteca ya existente.
+**Importante**: el comando `lyrics` (y `tuiBackend.Lyrics`) llama `config.ResolveDir(dir, false)` — no crea el directorio si no existe. El usuario debe apuntar a una biblioteca ya existente.
 
 ## Comando `lyrics` — detalles de implementación
 
@@ -365,6 +364,18 @@ lyrics_test.go    — buildLabel (formato, ancho fijo, truncado), lrcPathFor, sc
 
 ## Pendiente / Ideas
 
+- [x] Auditoría de sobreingeniería (`/ponytail-audit` sobre v1.5.0) — cerrada 2026-08-06.
+      15 hallazgos, −198 líneas, 0 dependencias eliminables. Los 2 primeros en `ec3b40a`
+      (dedup de reescritura FLAC y aplanado de páginas); los 13 restantes en cinco commits
+      temáticos: `rightAlign` en ui, `ResolveDir(dir, create)` + alias de flags por `BoolVar`
+      + `downloader.Qualities` en cmd, claves muertas de config, accesores/`encoding/binary`/
+      `isRemaster` en downloader, y código muerto en api.
+      Dos lecciones: (a) un test de datos completo no cubre un sitio de render que no consulta
+      la tabla — la mutación de `rightAlign` sin relleno pasaba `TestMenuRendersFullySpanish`
+      y solo la caza una aserción sobre el ancho real; (b) `buildFLACPictureBlock` aceptaba
+      `BigEndian`→`LittleEndian` sin que fallara nada, así que el swap a stdlib llegó con su
+      propio test de layout.
+
 - [x] Tests de integración con servidor mock completo para `downloader` — `integration_test.go`
       8 tests (11 con subtests): álbum completo, tagging real, tracks no disponibles, multi-disco,
       salto por DB entre ejecuciones, paridad con 1/2/3/8 workers, contexto cancelado, `HandleURL`.
@@ -394,7 +405,8 @@ lyrics_test.go    — buildLabel (formato, ancho fijo, truncado), lrcPathFor, sc
       `album.go` (545) seguía partido en dos clusters (0.57 y 0.40) → `album.go` + `track.go`.
       `smartDiscogFilter` vive con `downloadArtist`, su único llamador; los helpers de
       `downloadWithProgress` salen enteros a `transfer.go` (cluster de cohesión 0.93).
-      `getFloat` se queda en `helpers.go`, no en `search.go`: `metadata.go` también lo llama.
+      `getFloat` se quedó en `helpers.go`, no en `search.go`: `metadata.go` también lo llamaba.
+      (Desde 2026-08-06 ya no existe: era `nestedFloat` con la clave anidada vacía.)
 - [x] Deuda de complejidad cognitiva — cerrada 2026-07-27 (ver tabla arriba):
       `main()` repartido en dispatcher + `flags.go`; `decodeID3Text` partido por codificación
       (y arreglado el bug de Latin-1); `smartDiscogFilter` partido en

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,15 +76,23 @@ Usa la primera cuando el mensaje deba verse al momento (un track que falla), la 
 
 Con `--tui` la regla es más estricta: bubbletea está en alt-screen y **nada** puede llegar a stdout, así que `termOut()` devuelve `io.Discard`. Por eso todos los mensajes del paquete (incluidos `lastfm.go` y `csvbatch.go`) van por `d.termOut()` y no por `fmt.Printf`. Las funciones libres (`makeM3U`, `printBatchSummary`, `tagFLAC`) reciben el `io.Writer` como parámetro.
 
+**`os.Stderr` cuenta igual que stdout**: la alt-screen se traga los dos. Un error que el
+usuario tiene que ver se **devuelve**, no se imprime — `DownloadCSV` devuelve el fallo de
+parseo y `runDisplay` propaga el de `fn`, que se reporta con la pantalla ya cerrada. Bajo
+la TUI el shell lo pinta en su línea de estado; en CLI acaba en `fatalf`, o sea stderr y
+exit 1.
+
 Las dos excepciones son `interactive.go` y `oauth.go`: el REPL de `fun` es dueño de su
 terminal y nunca corre con barras, y OAuth solo imprime con la terminal liberada por
 `ReleaseTerminal`. Están en la allowlist de `TestNoDirectStdoutWrites`.
 
-**Esa regla se rompió tres veces sin que nada lo notara** (arreglado 2026-08-06):
+**Esa regla se rompió ocho veces sin que nada lo notara** (arreglado 2026-08-06):
 `tagFLAC`, `csvbatch.go` y `lastfm.go` tenían un `fmt.Print*` a un par de líneas de
-código que sí usaba `termOut()`. `TestTermOutDiscardsUnderTUI` no lo veía porque prueba
-que `termOut()` **devuelve** `io.Discard`, no que alguien lo **use**.
-`TestNoDirectStdoutWrites` escanea el paquete y cierra esa diferencia.
+código que sí usaba `termOut()`, y `csvbatch.go` otros cinco `os.Stderr` —tres de ellos
+dentro de `ParseCSV`, que corre bajo la TUI vía `DownloadCSV`.
+`TestTermOutDiscardsUnderTUI` no lo veía porque prueba que `termOut()` **devuelve**
+`io.Discard`, no que alguien lo **use**. `TestNoDirectStdoutWrites` escanea el paquete y
+cierra esa diferencia.
 
 ### Idioma de la TUI
 
@@ -191,7 +199,7 @@ Medido con `go test -cover ./...` el 2026-08-06:
 | api | 42.9% | client_test.go |
 | bundle | 59.7% | bundle_test.go |
 | config | 45.1% | config_test.go |
-| downloader | 45.1% | integration_test.go, oauth_test.go, tui_test.go, metadata_test.go, db_test.go, lastfm_test.go, helpers_test.go, redownload_test.go |
+| downloader | 48.7% | integration_test.go, oauth_test.go, tui_test.go, metadata_test.go, db_test.go, lastfm_test.go, helpers_test.go, redownload_test.go, csvbatch_test.go |
 | lyrics | 75.6% | metadata_test.go, lrclib_test.go, lyrics_test.go |
 | ui | 55.8% | shell_test.go, handle_test.go, lang_test.go |
 | cmd/qobuz-dl | 0% | main_test.go |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,12 +89,31 @@ lleva lock y no es seguro con el bucle de render corriendo. Va en `main()` y no 
 `runTUI` porque las dos pantallas lo necesitan (`tui` y `--tui`), y así `internal/ui`
 no depende de `internal/config`. Idioma ausente o desconocido → inglés.
 
-**Lección de los tests**: los tres tests de datos (tabla completa, sin claves
-huérfanas, sin español en el código) pasaban mientras la fila **seleccionada** del
-menú se renderizaba en inglés — se construía con `m.label` crudo mientras todas las
-demás pasaban por `T()`. Una tabla de traducción completa no puede detectar un sitio
-de render que no la consulta. `TestMenuRendersFullySpanish` mueve el cursor por todas
-las entradas y compara la salida real; es el único que lo caza.
+Los **errores** son la excepción y se quedan en inglés sin `T()`, igual que los de
+`api`, `config` y `downloader`: traducir solo los del backend TUI sería incoherente y
+los `%w` no son claves de tabla. Los mensajes de estado sí van por `T()` — el patrón
+lo marca `shell.go` (`s.status = T("working…")`, `fmt.Sprintf(T("%d in the queue"), n)`).
+`cmd/qobuz-dl/tui_cmd.go` está en `package main` y llama `ui.T()`.
+
+**Lección de los tests, en dos rondas.** Primera: los tres tests de datos (tabla
+completa, sin claves huérfanas, sin español en el código) pasaban mientras la fila
+**seleccionada** del menú se renderizaba en inglés — se construía con `m.label` crudo
+mientras todas las demás pasaban por `T()`. Una tabla de traducción completa no puede
+detectar un sitio de render que no la consulta. `TestMenuRendersFullySpanish` mueve el
+cursor por todas las entradas y compara la salida real.
+
+Segunda (2026-08-06): esos cuatro tests seguían verdes con 16 cadenas en español
+hardcodeadas. Tres agujeros distintos, los tres ahora cerrados:
+
+- `readUISources` leía una **lista fija de seis ficheros** de `internal/ui`, así que
+  `cmd/qobuz-dl/tui_cmd.go` no se miraba nunca. Ahora lee por directorio — una lista de
+  ficheros deja de cubrir todo lo que se añada después de escribirla.
+- La regex de `TestNoSpanishLeftInSources` solo miraba `ñÑ¿¡`; `"(vacío)"` pasaba.
+  Ampliada a vocales acentuadas.
+- **Español sin carácter distintivo** (`"%d completadas"`, `"Ctrl+C cancelar"`) es
+  invisible para cualquier escaneo de fuentes. Lo caza `TestEnglishRenderStaysEnglish`:
+  renderiza en inglés y falla si aparece cualquier **valor** del mapa `es`. Una cadena
+  hardcodeada sale idéntica en los dos idiomas, y eso no necesita lista de palabras.
 
 ### La TUI completa (`tui`)
 
@@ -164,7 +183,7 @@ Medido con `go test -cover ./...` el 2026-08-06:
 | config | 45.1% | config_test.go |
 | downloader | 45.1% | integration_test.go, oauth_test.go, tui_test.go, metadata_test.go, db_test.go, lastfm_test.go, helpers_test.go, redownload_test.go |
 | lyrics | 75.6% | metadata_test.go, lrclib_test.go, lyrics_test.go |
-| ui | 54.7% | shell_test.go, handle_test.go, lang_test.go |
+| ui | 55.8% | shell_test.go, handle_test.go, lang_test.go |
 | cmd/qobuz-dl | 0% | main_test.go |
 
 `cmd/qobuz-dl` marca 0% porque sus tests son **black-box**: compilan el binario en `TestMain` y lo ejecutan como subproceso, así que la cobertura no se instrumenta. No es falta de tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,17 @@ Cualquier nueva feature con feedback visual debe reutilizar este patrón para co
 
 Usa la primera cuando el mensaje deba verse al momento (un track que falla), la segunda cuando sea un resumen.
 
-Con `--tui` la regla es más estricta: bubbletea está en alt-screen y **nada** puede llegar a stdout, así que `termOut()` devuelve `io.Discard`. Por eso todos los mensajes del paquete (incluidos `lastfm.go` y `csvbatch.go`) van por `d.termOut()` y no por `fmt.Printf`. Las funciones libres (`makeM3U`, `printBatchSummary`) reciben el `io.Writer` como parámetro.
+Con `--tui` la regla es más estricta: bubbletea está en alt-screen y **nada** puede llegar a stdout, así que `termOut()` devuelve `io.Discard`. Por eso todos los mensajes del paquete (incluidos `lastfm.go` y `csvbatch.go`) van por `d.termOut()` y no por `fmt.Printf`. Las funciones libres (`makeM3U`, `printBatchSummary`, `tagFLAC`) reciben el `io.Writer` como parámetro.
+
+Las dos excepciones son `interactive.go` y `oauth.go`: el REPL de `fun` es dueño de su
+terminal y nunca corre con barras, y OAuth solo imprime con la terminal liberada por
+`ReleaseTerminal`. Están en la allowlist de `TestNoDirectStdoutWrites`.
+
+**Esa regla se rompió tres veces sin que nada lo notara** (arreglado 2026-08-06):
+`tagFLAC`, `csvbatch.go` y `lastfm.go` tenían un `fmt.Print*` a un par de líneas de
+código que sí usaba `termOut()`. `TestTermOutDiscardsUnderTUI` no lo veía porque prueba
+que `termOut()` **devuelve** `io.Discard`, no que alguien lo **use**.
+`TestNoDirectStdoutWrites` escanea el paquete y cierra esa diferencia.
 
 ### Idioma de la TUI
 

--- a/cmd/qobuz-dl/flags.go
+++ b/cmd/qobuz-dl/flags.go
@@ -88,7 +88,7 @@ func initDownloader(ctx context.Context, f *cliFlags) (*downloader.Downloader, e
 	if dir == "" {
 		dir = "./qobuz-downloader"
 	}
-	resolvedDir, err := config.ResolveDir(dir)
+	resolvedDir, err := config.ResolveDir(dir, true)
 	if err != nil {
 		return nil, fmt.Errorf("download directory: %w", err)
 	}
@@ -126,8 +126,7 @@ func initDownloader(ctx context.Context, f *cliFlags) (*downloader.Downloader, e
 		return nil, err
 	}
 
-	qualityNames := map[int]string{5: "5 - MP3", 6: "6 - 16 bit, 44.1kHz", 7: "7 - 24 bit, <96kHz", 27: "27 - 24 bit, >96kHz"}
-	fmt.Printf("\033[33mSet max quality: %s\033[0m\n", qualityNames[quality])
+	fmt.Printf("\033[33mSet max quality: %s\033[0m\n", downloader.Qualities[quality])
 
 	opts := downloader.Options{
 		Directory:       dir,

--- a/cmd/qobuz-dl/lyrics_cmd.go
+++ b/cmd/qobuz-dl/lyrics_cmd.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/Aeneaj/qobuz-dl-go/internal/config"
 	"github.com/Aeneaj/qobuz-dl-go/internal/lyrics"
@@ -45,7 +42,8 @@ Options:
 		scanDir = "./qobuz-downloader"
 	}
 
-	resolved, err := resolveScanDir(scanDir)
+	// create=false: lyrics scans an existing library, it never makes one.
+	resolved, err := config.ResolveDir(scanDir, false)
 	if err != nil {
 		fatalf("lyrics: %v", err)
 	}
@@ -53,27 +51,4 @@ Options:
 	if err := lyrics.Run(ctx, resolved); err != nil {
 		fatalf("lyrics: %v", err)
 	}
-}
-
-// resolveScanDir expands ~ and returns an absolute path.
-// Unlike config.ResolveDir it does NOT create the directory — the user must
-// point lyrics at an existing music library.
-func resolveScanDir(dir string) (string, error) {
-	if strings.HasPrefix(dir, "~/") || dir == "~" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("expand ~: %w", err)
-		}
-		dir = filepath.Join(home, dir[1:])
-	}
-	abs, err := filepath.Abs(dir)
-	if err != nil {
-		return "", fmt.Errorf("resolve path %q: %w", dir, err)
-	}
-	if info, err := os.Stat(abs); err != nil {
-		return "", fmt.Errorf("directory not found: %q", abs)
-	} else if !info.IsDir() {
-		return "", fmt.Errorf("%q is not a directory", abs)
-	}
-	return abs, nil
 }

--- a/cmd/qobuz-dl/main.go
+++ b/cmd/qobuz-dl/main.go
@@ -58,14 +58,17 @@ func main() {
 	fs := flag.NewFlagSet("qobuz-dl", flag.ExitOnError)
 	fs.Usage = func() { fmt.Print(usage) }
 
-	reset := fs.Bool("r", false, "")
-	resetLong := fs.Bool("reset", false, "")
-	showCfg := fs.Bool("s", false, "")
-	showCfgLong := fs.Bool("show-config", false, "")
-	purge := fs.Bool("p", false, "")
-	purgeLong := fs.Bool("purge", false, "")
-	showVer := fs.Bool("v", false, "")
-	showVerLong := fs.Bool("version", false, "")
+	// Short and long spellings bind to the same variable, so there is nothing
+	// to OR together at the use site.
+	var reset, showCfg, purge, showVer bool
+	fs.BoolVar(&reset, "r", false, "")
+	fs.BoolVar(&reset, "reset", false, "")
+	fs.BoolVar(&showCfg, "s", false, "")
+	fs.BoolVar(&showCfg, "show-config", false, "")
+	fs.BoolVar(&purge, "p", false, "")
+	fs.BoolVar(&purge, "purge", false, "")
+	fs.BoolVar(&showVer, "v", false, "")
+	fs.BoolVar(&showVer, "version", false, "")
 
 	flags := registerDownloadFlags(fs)
 	luckyType := fs.String("lucky-type", "album", "")
@@ -74,7 +77,7 @@ func main() {
 
 	fs.Parse(os.Args[1:])
 
-	if *showVer || *showVerLong {
+	if showVer {
 		fmt.Println("qobuz-dl", version)
 		return
 	}
@@ -87,13 +90,13 @@ func main() {
 
 	// Config actions need no credentials and never fall through to a command.
 	switch {
-	case *reset || *resetLong:
+	case reset:
 		runReset(ctx)
 		return
-	case *showCfg || *showCfgLong:
+	case showCfg:
 		showConfig()
 		return
-	case *purge || *purgeLong:
+	case purge:
 		purgeDB()
 		return
 	}

--- a/cmd/qobuz-dl/main.go
+++ b/cmd/qobuz-dl/main.go
@@ -185,16 +185,20 @@ func mustDownloader(ctx context.Context, f *cliFlags) *downloader.Downloader {
 	return dl
 }
 
-// runDisplay runs fn, wrapped in the bubbletea TUI when --tui is set.
+// runDisplay runs fn, wrapped in the bubbletea TUI when --tui is set, and
+// returns fn's error once the screen is down.
 //
 // The TUI runs in alt-screen raw mode, where Ctrl+C arrives as a key event
 // instead of SIGINT — so the signal context in main() never fires and the
 // download goroutine would keep running after the screen is gone. A derived
 // context cancelled on exit is what actually stops it.
-func runDisplay(ctx context.Context, dl *downloader.Downloader, f *cliFlags, fn func(context.Context)) {
+//
+// The error comes back rather than being printed inside fn for the same
+// reason: bubbletea owns the terminal until p.Run() returns, so reporting it
+// any earlier would land on the alt screen.
+func runDisplay(ctx context.Context, dl *downloader.Downloader, f *cliFlags, fn func(context.Context) error) error {
 	if !f.TUI {
-		fn(ctx)
-		return
+		return fn(ctx)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -203,20 +207,22 @@ func runDisplay(ctx context.Context, dl *downloader.Downloader, f *cliFlags, fn 
 	p := tea.NewProgram(ui.NewModel(), tea.WithAltScreen(), tea.WithContext(ctx))
 	dl.SetUI(p)
 
+	errc := make(chan error, 1)
 	go func() {
-		fn(ctx)
+		errc <- fn(ctx)
 		p.Quit()
 	}()
 
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "TUI error: %v\n", err)
 	}
+	return <-errc
 }
 
 func runDL(ctx context.Context, args []string, f *cliFlags) {
 	requireArgs(args, "dl", "provide at least one URL")
 	dl := mustDownloader(ctx, f)
-	runDisplay(ctx, dl, f, func(ctx context.Context) { dl.DownloadURLs(ctx, args) })
+	runDisplay(ctx, dl, f, func(ctx context.Context) error { dl.DownloadURLs(ctx, args); return nil })
 }
 
 func runLucky(ctx context.Context, args []string, f *cliFlags, itemType string, n int) {
@@ -231,13 +237,18 @@ func runLucky(ctx context.Context, args []string, f *cliFlags, itemType string, 
 	if err != nil {
 		fatalf("%v", err)
 	}
-	runDisplay(ctx, dl, f, func(ctx context.Context) { dl.DownloadURLs(ctx, urls) })
+	runDisplay(ctx, dl, f, func(ctx context.Context) error { dl.DownloadURLs(ctx, urls); return nil })
 }
 
 func runCSV(ctx context.Context, args []string, f *cliFlags, failedCSV string) {
 	requireArgs(args, "csv", "provide path to a TuneMyMusic CSV file")
 	dl := mustDownloader(ctx, f)
-	runDisplay(ctx, dl, f, func(ctx context.Context) { dl.DownloadCSV(ctx, args[0], failedCSV) })
+	err := runDisplay(ctx, dl, f, func(ctx context.Context) error {
+		return dl.DownloadCSV(ctx, args[0], failedCSV)
+	})
+	if err != nil {
+		fatalf("csv: %v", err)
+	}
 }
 
 func fatalf(format string, a ...interface{}) {

--- a/cmd/qobuz-dl/main_test.go
+++ b/cmd/qobuz-dl/main_test.go
@@ -179,8 +179,9 @@ func TestAdvertisedFlagsExist(t *testing.T) {
 	root := filepath.Dir(filepath.Dir(wd)) // repo root, from cmd/qobuz-dl
 
 	var (
-		reAdvice   = regexp.MustCompile(`qobuz-dl ((?:--[a-z-]+ ?)+)`)
-		reRegister = regexp.MustCompile(`fs\.(?:Bool|String|Int)\("([a-z-]+)"`)
+		reAdvice = regexp.MustCompile(`qobuz-dl ((?:--[a-z-]+ ?)+)`)
+		// Both spellings: fs.Bool("x", …) and fs.BoolVar(&v, "x", …).
+		reRegister = regexp.MustCompile(`fs\.(?:Bool|String|Int)(?:Var\(&\w+, )?\(?"([a-z-]+)"`)
 		advertised = map[string]string{} // flag -> file advertising it
 		registered = map[string]bool{}
 	)

--- a/cmd/qobuz-dl/tui_cmd.go
+++ b/cmd/qobuz-dl/tui_cmd.go
@@ -132,7 +132,9 @@ func (b *tuiBackend) CSV(ctx context.Context, path string) (string, error) {
 	if _, err := os.Stat(path); err != nil {
 		return "", fmt.Errorf("CSV not found: %s", path)
 	}
-	b.dl.DownloadCSV(ctx, path, "failed_downloads.csv")
+	if err := b.dl.DownloadCSV(ctx, path, "failed_downloads.csv"); err != nil {
+		return "", err
+	}
 	return ui.T("CSV import finished"), nil
 }
 

--- a/cmd/qobuz-dl/tui_cmd.go
+++ b/cmd/qobuz-dl/tui_cmd.go
@@ -139,7 +139,7 @@ func (b *tuiBackend) CSV(ctx context.Context, path string) (string, error) {
 // Lyrics needs no Qobuz session — LRCLIB is public — so it deliberately skips
 // the b.dl check and works before login.
 func (b *tuiBackend) Lyrics(ctx context.Context, dir string) (string, error) {
-	resolved, err := resolveScanDir(dir)
+	resolved, err := config.ResolveDir(dir, false)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/qobuz-dl/tui_cmd.go
+++ b/cmd/qobuz-dl/tui_cmd.go
@@ -17,7 +17,7 @@ import (
 
 // errNoSession is what every Qobuz-backed action returns before login. It
 // names the menu entry that fixes it, since that is where the user is looking.
-var errNoSession = errors.New("sin sesión — elige «Iniciar sesión (OAuth)» en el menú")
+var errNoSession = errors.New(`not signed in — choose "Log in (OAuth)" in the menu`)
 
 // runTUI opens the full-program TUI: menu, search, queue, downloads, lyrics,
 // CSV import and config.
@@ -66,7 +66,7 @@ func (b *tuiBackend) session() error {
 	case b.dl != nil:
 		return nil
 	case b.bootErr != nil:
-		return fmt.Errorf("%w — o elige «Iniciar sesión (OAuth)» en el menú", b.bootErr)
+		return fmt.Errorf(`%w — or choose "Log in (OAuth)" in the menu`, b.bootErr)
 	default:
 		return errNoSession
 	}
@@ -83,7 +83,7 @@ func (b *tuiBackend) LoggedIn() bool { return b.dl != nil }
 // the CLI flow verbatim correct, rather than merely convenient.
 func (b *tuiBackend) Login(ctx context.Context) (string, error) {
 	if err := b.prog.ReleaseTerminal(); err != nil {
-		return "", fmt.Errorf("no se pudo liberar la terminal: %w", err)
+		return "", fmt.Errorf("could not release the terminal: %w", err)
 	}
 	defer b.prog.RestoreTerminal() //nolint:errcheck
 
@@ -99,7 +99,7 @@ func (b *tuiBackend) Login(ctx context.Context) (string, error) {
 	dl.SetUI(b.prog)
 	b.dl = dl
 	b.bootErr = nil
-	return "sesión iniciada", nil
+	return ui.T("signed in successfully"), nil
 }
 
 func (b *tuiBackend) Search(ctx context.Context, kind, query string, limit int) ([]ui.Item, error) {
@@ -130,10 +130,10 @@ func (b *tuiBackend) CSV(ctx context.Context, path string) (string, error) {
 		return "", err
 	}
 	if _, err := os.Stat(path); err != nil {
-		return "", fmt.Errorf("no se encuentra el CSV: %s", path)
+		return "", fmt.Errorf("CSV not found: %s", path)
 	}
 	b.dl.DownloadCSV(ctx, path, "failed_downloads.csv")
-	return "importación CSV terminada", nil
+	return ui.T("CSV import finished"), nil
 }
 
 // Lyrics needs no Qobuz session — LRCLIB is public — so it deliberately skips
@@ -144,10 +144,10 @@ func (b *tuiBackend) Lyrics(ctx context.Context, dir string) (string, error) {
 		return "", err
 	}
 
-	b.prog.Send(ui.MsgStatus{Text: "escaneando " + resolved + "…"})
+	b.prog.Send(ui.MsgStatus{Text: fmt.Sprintf(ui.T("scanning %s…"), resolved)})
 	res, err := lyrics.FetchAll(ctx, resolved, func(done, total int, title, artist string) {
 		if done == 0 {
-			b.prog.Send(ui.MsgStatus{Text: fmt.Sprintf("%d archivos de audio encontrados", total)})
+			b.prog.Send(ui.MsgStatus{Text: fmt.Sprintf(ui.T("%d audio files found"), total)})
 			return
 		}
 		b.prog.Send(ui.MsgStatus{Text: fmt.Sprintf("[%d/%d] %s — %s", done, total, title, artist)})
@@ -156,9 +156,9 @@ func (b *tuiBackend) Lyrics(ctx context.Context, dir string) (string, error) {
 		return "", err
 	}
 	if res.Total == 0 {
-		return "no se encontró audio en esa carpeta", nil
+		return ui.T("no audio found in that folder"), nil
 	}
-	return fmt.Sprintf("letras: %d nuevas · %d ya estaban · %d sin resultado",
+	return fmt.Sprintf(ui.T("lyrics: %d new · %d already there · %d without a match"),
 		res.Fetched, res.Skipped, len(res.Warnings)), nil
 }
 
@@ -166,7 +166,7 @@ func (b *tuiBackend) Config() string {
 	path := filepath.Join(config.ConfigDir(), "config.ini")
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return "no se pudo leer la configuración: " + err.Error()
+		return ui.T("could not read the settings") + ": " + err.Error()
 	}
 	return path + "\n\n" + string(data)
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -326,22 +326,6 @@ func (c *Client) GetTrackURL(ctx context.Context, trackID string, fmtID int, sec
 	})
 }
 
-// GetFavoriteAlbums returns the user's favorite albums.
-func (c *Client) GetFavoriteAlbums(ctx context.Context, offset, limit int) (map[string]interface{}, error) {
-	unix := strconv.FormatInt(time.Now().Unix(), 10)
-	rawSig := "favoritegetUserFavorites" + unix + c.Secret
-	sig := md5hex(rawSig)
-	return c.doGet(ctx, "favorite/getUserFavorites", url.Values{
-		"app_id":          {c.AppID},
-		"user_auth_token": {c.UAT},
-		"type":            {"albums"},
-		"request_ts":      {unix},
-		"request_sig":     {sig},
-		"limit":           {strconv.Itoa(limit)},
-		"offset":          {strconv.Itoa(offset)},
-	})
-}
-
 // SearchAlbums searches for albums.
 func (c *Client) SearchAlbums(ctx context.Context, query string, limit int) (map[string]interface{}, error) {
 	return c.doGet(ctx, "album/search", url.Values{"query": {query}, "limit": {strconv.Itoa(limit)}})

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -149,7 +149,6 @@ func TestErrorTypes(t *testing.T) {
 		&InvalidAppIDError{"test"},
 		&InvalidAppSecretError{"test"},
 		&InvalidQualityError{"test"},
-		&NonStreamableError{"test"},
 	}
 	for _, err := range errs {
 		if err.Error() == "" {

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -7,11 +7,9 @@ type IneligibleError struct{ msg string }
 type InvalidAppIDError struct{ msg string }
 type InvalidAppSecretError struct{ msg string }
 type InvalidQualityError struct{ msg string }
-type NonStreamableError struct{ msg string }
 
 func (e *AuthenticationError) Error() string   { return fmt.Sprintf("authentication error: %s", e.msg) }
 func (e *IneligibleError) Error() string       { return fmt.Sprintf("ineligible: %s", e.msg) }
 func (e *InvalidAppIDError) Error() string     { return fmt.Sprintf("invalid app id: %s", e.msg) }
 func (e *InvalidAppSecretError) Error() string { return fmt.Sprintf("invalid app secret: %s", e.msg) }
 func (e *InvalidQualityError) Error() string   { return fmt.Sprintf("invalid quality: %s", e.msg) }
-func (e *NonStreamableError) Error() string    { return fmt.Sprintf("non streamable: %s", e.msg) }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,9 +59,7 @@ type Config struct {
 	UserAuthToken  string
 	DownloadDir    string
 	Lang           string
-	DefaultFolder  string
 	DefaultQuality int
-	DefaultLimit   int
 	NoM3U          bool
 	AlbumsOnly     bool
 	NoFallback     bool
@@ -142,9 +140,7 @@ func Load() (*Config, error) {
 		UserAuthToken:  get("user_auth_token", ""),
 		DownloadDir:    get("download_dir", ""),
 		Lang:           get("lang", ""),
-		DefaultFolder:  get("default_folder", "Qobuz Downloads"),
 		DefaultQuality: getInt("default_quality", 6),
-		DefaultLimit:   getInt("default_limit", 20),
 		NoM3U:          getBool("no_m3u"),
 		AlbumsOnly:     getBool("albums_only"),
 		NoFallback:     getBool("no_fallback"),
@@ -168,9 +164,7 @@ func Load() (*Config, error) {
 // Shared by Reset and InitConfig. ctx cancels the bundle.Fetch HTTP calls.
 func setupPreferences(ctx context.Context, kv map[string]string) error {
 	kv["download_dir"] = prompt("Enter default download directory (leave blank for ./qobuz-downloader):\n- ")
-	kv["default_folder"] = promptDefault("Folder for downloads (leave empty for 'Qobuz Downloads')\n- ", "Qobuz Downloads")
 	kv["default_quality"] = promptDefault("Download quality (5, 6, 7, 27) [320, LOSSLESS, 24B <96KHZ, 24B >96KHZ]\n(leave empty for '6')\n- ", "6")
-	kv["default_limit"] = "20"
 	kv["no_m3u"] = "false"
 	kv["albums_only"] = "false"
 	kv["no_fallback"] = "false"
@@ -180,9 +174,6 @@ func setupPreferences(ctx context.Context, kv map[string]string) error {
 	kv["no_database"] = "false"
 	kv["smart_discography"] = "false"
 	kv["workers"] = "3"
-	// Kept for backward compat reading old configs; never written by Reset
-	kv["email"] = ""
-	kv["password"] = ""
 	kv["folder_format"] = DefaultFolder
 	kv["track_format"] = DefaultTrack
 
@@ -330,10 +321,11 @@ func readINI(path string) (map[string]string, error) {
 }
 
 func writeINI(path string, kv map[string]string) error {
+	// Keys this version writes, in output order. Anything else already in the
+	// file (keys from older versions) is preserved after these — see below.
 	order := []string{
 		"user_id", "user_auth_token",
-		"email", "password", // legacy — kept for reading old configs
-		"download_dir", "default_folder", "default_quality", "default_limit",
+		"download_dir", "default_quality",
 		"no_m3u", "albums_only", "no_fallback", "og_cover",
 		"embed_art", "no_cover", "no_database", "smart_discography",
 		"workers",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,9 +14,10 @@ import (
 	"github.com/Aeneaj/qobuz-dl-go/internal/bundle"
 )
 
-// ResolveDir expands ~ and relative paths, then creates the directory tree.
-// Returns the absolute path ready to use, or an error if creation fails.
-func ResolveDir(dir string) (string, error) {
+// ResolveDir expands ~ and relative paths and returns the absolute path.
+// With create it makes the directory tree; without it the directory must
+// already exist — which is what scanning an existing music library needs.
+func ResolveDir(dir string, create bool) (string, error) {
 	if dir == "" {
 		return "", fmt.Errorf("directory path is empty")
 	}
@@ -31,8 +32,18 @@ func ResolveDir(dir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve path %q: %w", dir, err)
 	}
-	if err := os.MkdirAll(abs, 0755); err != nil {
-		return "", fmt.Errorf("create directory %q: %w", abs, err)
+	if create {
+		if err := os.MkdirAll(abs, 0755); err != nil {
+			return "", fmt.Errorf("create directory %q: %w", abs, err)
+		}
+		return abs, nil
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", fmt.Errorf("directory not found: %q", abs)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%q is not a directory", abs)
 	}
 	return abs, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -227,3 +227,37 @@ func TestWriteINI_StableKeyOrder(t *testing.T) {
 		t.Errorf("expected email before app_id in output")
 	}
 }
+
+func TestResolveDir_CreateFlag(t *testing.T) {
+	base := t.TempDir()
+	missing := filepath.Join(base, "nope")
+
+	// create=false must not bring the directory into existence.
+	if _, err := ResolveDir(missing, false); err == nil {
+		t.Fatal("ResolveDir(missing, false) = nil error, want 'directory not found'")
+	}
+	if _, err := os.Stat(missing); err == nil {
+		t.Fatal("ResolveDir(missing, false) created the directory")
+	}
+
+	// create=true must.
+	got, err := ResolveDir(missing, true)
+	if err != nil {
+		t.Fatalf("ResolveDir(missing, true): %v", err)
+	}
+	if got != missing {
+		t.Errorf("ResolveDir = %q, want %q", got, missing)
+	}
+	if info, err := os.Stat(missing); err != nil || !info.IsDir() {
+		t.Fatal("ResolveDir(missing, true) did not create the directory")
+	}
+
+	// A file is not a directory, whatever the flag says.
+	file := filepath.Join(base, "f.txt")
+	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ResolveDir(file, false); err == nil {
+		t.Error("ResolveDir(file, false) = nil error, want 'is not a directory'")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -211,20 +211,23 @@ func TestWriteINI_StableKeyOrder(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.ini")
 	kv := map[string]string{
-		"email":    "a@b.com",
-		"password": "hash",
-		"app_id":   "123",
-		"secrets":  "s1,s2",
+		"secrets": "s1,s2",
+		"app_id":  "123",
+		"user_id": "42",
+		"email":   "a@b.com", // retired key, not in the ordered list
 	}
 	writeINI(path, kv)
 
 	data, _ := os.ReadFile(path)
 	content := string(data)
-	// email should appear before app_id (per ordered list)
-	emailPos := strings.Index(content, "email")
-	appIDPos := strings.Index(content, "app_id")
-	if emailPos > appIDPos {
-		t.Errorf("expected email before app_id in output")
+	// user_id comes before app_id per the ordered list, whatever order the
+	// map iterates in.
+	if strings.Index(content, "user_id") > strings.Index(content, "app_id") {
+		t.Errorf("expected user_id before app_id in output:\n%s", content)
+	}
+	// Retired keys are written after the ordered ones, never dropped.
+	if strings.Index(content, "email") < strings.Index(content, "app_id") {
+		t.Errorf("expected the retired email key after app_id in output:\n%s", content)
 	}
 }
 

--- a/internal/downloader/collection.go
+++ b/internal/downloader/collection.go
@@ -9,15 +9,12 @@ import (
 	"strings"
 )
 
-func (d *Downloader) downloadArtist(ctx context.Context, pages []map[string]interface{}) error {
-	if len(pages) == 0 {
-		return nil
-	}
-	name, _ := pages[0]["name"].(string)
-
+// collectPageItems flattens the items of every page under the given section
+// key (e.g. "albums", "tracks"), skipping pages that lack the section.
+func collectPageItems(pages []map[string]interface{}, key string) []map[string]interface{} {
 	var items []map[string]interface{}
 	for _, page := range pages {
-		section, _ := page["albums"].(map[string]interface{})
+		section, _ := page[key].(map[string]interface{})
 		if section == nil {
 			continue
 		}
@@ -28,16 +25,30 @@ func (d *Downloader) downloadArtist(ctx context.Context, pages []map[string]inte
 			}
 		}
 	}
+	return items
+}
 
-	if d.Opts.SmartDiscog {
+// downloadAlbumCollection downloads every album listed under itemKey in pages
+// into a directory named after the collection. kind names the collection in
+// the console output. smartDiscog applies the discography filter, which only
+// makes sense when the albums all belong to the collection's own artist — for
+// a label it would compare each album's artist against the label name and
+// discard everything.
+func (d *Downloader) downloadAlbumCollection(ctx context.Context, pages []map[string]interface{}, itemKey, kind string, smartDiscog bool) error {
+	if len(pages) == 0 {
+		return nil
+	}
+	name, _ := pages[0]["name"].(string)
+	items := collectPageItems(pages, itemKey)
+	if smartDiscog {
 		items = smartDiscogFilter(name, items)
 	}
 
 	dir := filepath.Join(d.Opts.Directory, sanitize(name))
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("create artist directory %q: %w", dir, err)
+		return fmt.Errorf("create %s directory %q: %w", kind, dir, err)
 	}
-	fmt.Fprintf(d.termOut(), "\033[33mDownloading discography: %s (%d albums)\033[0m\n", name, len(items))
+	fmt.Fprintf(d.termOut(), "\033[33mDownloading %s: %s (%d albums)\033[0m\n", kind, name, len(items))
 
 	for _, item := range items {
 		id := idStr(item["id"])
@@ -58,20 +69,7 @@ func (d *Downloader) downloadPlaylist(ctx context.Context, pages []map[string]in
 		return fmt.Errorf("create playlist directory %q: %w", dir, err)
 	}
 
-	var items []map[string]interface{}
-	for _, page := range pages {
-		section, _ := page["tracks"].(map[string]interface{})
-		if section == nil {
-			continue
-		}
-		raw, _ := section["items"].([]interface{})
-		for _, r := range raw {
-			if m, ok := r.(map[string]interface{}); ok {
-				items = append(items, m)
-			}
-		}
-	}
-
+	items := collectPageItems(pages, "tracks")
 	fmt.Fprintf(d.termOut(), "\033[33mDownloading playlist: %s (%d tracks)\033[0m\n", name, len(items))
 	for _, item := range items {
 		id := idStr(item["id"])
@@ -82,40 +80,6 @@ func (d *Downloader) downloadPlaylist(ctx context.Context, pages []map[string]in
 
 	if !d.Opts.NoM3U {
 		makeM3U(d.termOut(), dir)
-	}
-	return nil
-}
-
-func (d *Downloader) downloadLabelOrArtist(ctx context.Context, pages []map[string]interface{}, itemKey, collectionType string) error {
-	if len(pages) == 0 {
-		return nil
-	}
-	name, _ := pages[0]["name"].(string)
-	dir := filepath.Join(d.Opts.Directory, sanitize(name))
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("create %s directory %q: %w", collectionType, dir, err)
-	}
-
-	var items []map[string]interface{}
-	for _, page := range pages {
-		section, _ := page[itemKey].(map[string]interface{})
-		if section == nil {
-			continue
-		}
-		raw, _ := section["items"].([]interface{})
-		for _, r := range raw {
-			if m, ok := r.(map[string]interface{}); ok {
-				items = append(items, m)
-			}
-		}
-	}
-
-	fmt.Fprintf(d.termOut(), "\033[33mDownloading %s: %s (%d albums)\033[0m\n", collectionType, name, len(items))
-	for _, item := range items {
-		id := idStr(item["id"])
-		if err := d.downloadAlbum(ctx, id, dir); err != nil {
-			fmt.Fprintf(d.termOut(), "\033[31mError on album %s: %v. Skipping...\033[0m\n", id, err)
-		}
 	}
 	return nil
 }

--- a/internal/downloader/collection.go
+++ b/internal/downloader/collection.go
@@ -86,7 +86,6 @@ func (d *Downloader) downloadPlaylist(ctx context.Context, pages []map[string]in
 
 var (
 	reRemaster = regexp.MustCompile(`(?i)(re)?master(ed)?`)
-	reExtra    = regexp.MustCompile(`(?i)(anniversary|deluxe|live|collector|demo|expanded)`)
 	reEssence  = regexp.MustCompile(`^([^(]+)`)
 )
 
@@ -135,7 +134,7 @@ func pickBest(requestedArtist string, albums []map[string]interface{}) (map[stri
 	// One pass for the aggregates, caching each album's "is remaster" flag so
 	// the regex runs once per album rather than again in the selection loop.
 	var q groupQuality
-	isRemaster := make([]bool, len(albums))
+	remastered := make([]bool, len(albums))
 	for i, a := range albums {
 		bd, _ := a["maximum_bit_depth"].(float64)
 		sr, _ := a["maximum_sampling_rate"].(float64)
@@ -145,14 +144,14 @@ func pickBest(requestedArtist string, albums []map[string]interface{}) (map[stri
 		case bd == q.bestBitDepth && sr > q.bestSampleRate:
 			q.bestSampleRate = sr
 		}
-		if isAlbumType("remaster", a) {
-			isRemaster[i] = true
+		if isRemaster(a) {
+			remastered[i] = true
 			q.hasRemaster = true
 		}
 	}
 
 	for i, a := range albums {
-		if qualifies(a, q, isRemaster[i], requestedArtist) {
+		if qualifies(a, q, remastered[i], requestedArtist) {
 			return a, true
 		}
 	}
@@ -181,15 +180,8 @@ func essenceTitle(title string) string {
 	return strings.ToLower(strings.TrimSpace(m))
 }
 
-func isAlbumType(t string, album map[string]interface{}) bool {
+func isRemaster(album map[string]interface{}) bool {
 	title, _ := album["title"].(string)
 	version, _ := album["version"].(string)
-	combined := title + " " + version
-	switch t {
-	case "remaster":
-		return reRemaster.MatchString(combined)
-	case "extra":
-		return reExtra.MatchString(combined)
-	}
-	return false
+	return reRemaster.MatchString(title + " " + version)
 }

--- a/internal/downloader/collection_test.go
+++ b/internal/downloader/collection_test.go
@@ -1,0 +1,53 @@
+package downloader
+
+import "testing"
+
+// collectPageItems is the flattening step shared by the artist, label and
+// playlist flows. Paginated responses are the case worth pinning down: the
+// Qobuz API splits collections into pages of 500, so an artist with a long
+// discography arrives as several pages that must be concatenated in order.
+func TestCollectPageItems(t *testing.T) {
+	page := func(key string, ids ...string) map[string]interface{} {
+		items := make([]interface{}, len(ids))
+		for i, id := range ids {
+			items[i] = map[string]interface{}{"id": id}
+		}
+		return map[string]interface{}{key: map[string]interface{}{"items": items}}
+	}
+
+	cases := []struct {
+		name  string
+		pages []map[string]interface{}
+		key   string
+		want  []string
+	}{
+		{"single page", []map[string]interface{}{page("albums", "a", "b")}, "albums", []string{"a", "b"}},
+		{
+			"concatenated in page order",
+			[]map[string]interface{}{page("albums", "a"), page("albums", "b", "c")},
+			"albums", []string{"a", "b", "c"},
+		},
+		{
+			"page without the section is skipped",
+			[]map[string]interface{}{{"name": "x"}, page("albums", "a")},
+			"albums", []string{"a"},
+		},
+		{"wrong key yields nothing", []map[string]interface{}{page("albums", "a")}, "tracks", nil},
+		{"no pages", nil, "albums", nil},
+		{"section present but empty", []map[string]interface{}{page("tracks")}, "tracks", nil},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := collectPageItems(c.pages, c.key)
+			if len(got) != len(c.want) {
+				t.Fatalf("got %d items, want %d", len(got), len(c.want))
+			}
+			for i, want := range c.want {
+				if id := idStr(got[i]["id"]); id != want {
+					t.Errorf("item %d = %q, want %q", i, id, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/downloader/csvbatch.go
+++ b/internal/downloader/csvbatch.go
@@ -26,7 +26,10 @@ type TrackRequest struct {
 //
 // Handles the common TuneMyMusic anomaly where Artist name is empty and
 // Track name contains "Artist - Title" format.
-func ParseCSV(path string) ([]TrackRequest, error) {
+// w receives the per-row warnings. It must be the downloader's termOut() —
+// these run under the TUI via DownloadCSV, where stdout and stderr both land
+// on top of the alt screen.
+func ParseCSV(w io.Writer, path string) ([]TrackRequest, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open csv: %w", err)
@@ -55,7 +58,7 @@ func ParseCSV(path string) ([]TrackRequest, error) {
 
 	// Warn if the critical column is missing — helps diagnose future format changes.
 	if _, ok := colIdx["Track name"]; !ok {
-		fmt.Fprintf(os.Stderr, "\033[33mWarning: 'Track name' column not found in header. Got: %v\033[0m\n", header)
+		fmt.Fprintf(w, "\033[33mWarning: 'Track name' column not found in header. Got: %v\033[0m\n", header)
 	}
 
 	get := func(record []string, name string) string {
@@ -75,13 +78,13 @@ func ParseCSV(path string) ([]TrackRequest, error) {
 		}
 		rowNum++
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "\033[33m  [row %d] skipped: parse error: %v\033[0m\n", rowNum, err)
+			fmt.Fprintf(w, "\033[33m  [row %d] skipped: parse error: %v\033[0m\n", rowNum, err)
 			continue
 		}
 
 		raw := get(record, "Track name")
 		if raw == "" {
-			fmt.Fprintf(os.Stderr, "\033[33m  [row %d] skipped: empty Track name\033[0m\n", rowNum)
+			fmt.Fprintf(w, "\033[33m  [row %d] skipped: empty Track name\033[0m\n", rowNum)
 			continue
 		}
 
@@ -125,15 +128,14 @@ type failedEntry struct {
 
 // DownloadCSV parses the CSV at csvPath and downloads each track via Qobuz.
 // If failedPath is non-empty, writes a CSV report of skipped/failed tracks there.
-func (d *Downloader) DownloadCSV(ctx context.Context, csvPath, failedPath string) {
-	tracks, err := ParseCSV(csvPath)
+func (d *Downloader) DownloadCSV(ctx context.Context, csvPath, failedPath string) error {
+	tracks, err := ParseCSV(d.termOut(), csvPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "\033[31mCSV parse error: %v\033[0m\n", err)
-		return
+		return fmt.Errorf("CSV parse error: %w", err)
 	}
 	if len(tracks) == 0 {
 		fmt.Fprintln(d.termOut(), "No tracks found in CSV.")
-		return
+		return nil
 	}
 
 	fmt.Fprintf(d.termOut(), "\033[33mCSV loaded: %d tracks to process\033[0m\n\n", len(tracks))
@@ -175,11 +177,12 @@ func (d *Downloader) DownloadCSV(ctx context.Context, csvPath, failedPath string
 
 	if failedPath != "" && len(failures) > 0 {
 		if err := writeFailedCSV(failedPath, failures); err != nil {
-			fmt.Fprintf(os.Stderr, "  \033[31mCould not write failed report: %v\033[0m\n", err)
+			fmt.Fprintf(d.termOut(), "  \033[31mCould not write failed report: %v\033[0m\n", err)
 		} else {
 			fmt.Fprintf(d.termOut(), "  Failed tracks saved to: %s\n", failedPath)
 		}
 	}
+	return nil
 }
 
 func printBatchSummary(w io.Writer, total, downloaded int, failures []failedEntry) {

--- a/internal/downloader/csvbatch.go
+++ b/internal/downloader/csvbatch.go
@@ -132,7 +132,7 @@ func (d *Downloader) DownloadCSV(ctx context.Context, csvPath, failedPath string
 		return
 	}
 	if len(tracks) == 0 {
-		fmt.Println("No tracks found in CSV.")
+		fmt.Fprintln(d.termOut(), "No tracks found in CSV.")
 		return
 	}
 

--- a/internal/downloader/csvbatch_test.go
+++ b/internal/downloader/csvbatch_test.go
@@ -1,0 +1,83 @@
+package downloader
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeCSV(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "playlist.csv")
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestParseCSVWarningsGoToWriter pins where the per-row warnings land. They
+// used to go to os.Stderr, which paints over the alt screen when the TUI runs
+// an import — the writer is the whole point of the parameter, so a warning
+// that skips it is the failure this catches.
+func TestParseCSVWarningsGoToWriter(t *testing.T) {
+	path := writeCSV(t, "Track name,Artist name,Album\n"+
+		"Karma Police,Radiohead,OK Computer\n"+
+		",Nobody,Empty Title\n"+ // skipped: empty Track name
+		"Paranoid Android,Radiohead,OK Computer\n")
+
+	var buf bytes.Buffer
+	tracks, err := ParseCSV(&buf, path)
+	if err != nil {
+		t.Fatalf("ParseCSV: %v", err)
+	}
+
+	if len(tracks) != 2 {
+		t.Errorf("parsed %d tracks, want 2 (the empty-title row is skipped)", len(tracks))
+	}
+	if !strings.Contains(buf.String(), "empty Track name") {
+		t.Errorf("the skipped-row warning did not reach the writer, got: %q", buf.String())
+	}
+}
+
+// A missing "Track name" column is the anomaly worth shouting about, and its
+// warning has the same destination requirement.
+func TestParseCSVMissingColumnWarnsToWriter(t *testing.T) {
+	path := writeCSV(t, "Song,Artist name\nKarma Police,Radiohead\n")
+
+	var buf bytes.Buffer
+	if _, err := ParseCSV(&buf, path); err != nil {
+		t.Fatalf("ParseCSV: %v", err)
+	}
+	if !strings.Contains(buf.String(), "'Track name' column not found") {
+		t.Errorf("the missing-column warning did not reach the writer, got: %q", buf.String())
+	}
+}
+
+// TestDownloadCSVReturnsParseError covers the other half: an unreadable CSV is
+// reported to the caller instead of printed. Under the TUI the caller is the
+// shell, which puts it on its own status line; printing it would land on the
+// alt screen.
+func TestDownloadCSVReturnsParseError(t *testing.T) {
+	d := &Downloader{}
+	missing := filepath.Join(t.TempDir(), "does-not-exist.csv")
+
+	err := d.DownloadCSV(context.Background(), missing, "")
+	if err == nil {
+		t.Fatal("DownloadCSV on a missing file returned nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "CSV parse error") {
+		t.Errorf("error = %q, want it to name the parse failure", err)
+	}
+}
+
+// An empty but valid CSV is not an error — there is simply nothing to do.
+func TestDownloadCSVEmptyIsNotAnError(t *testing.T) {
+	path := writeCSV(t, "Track name,Artist name\n")
+
+	if err := (&Downloader{}).DownloadCSV(context.Background(), path, ""); err != nil {
+		t.Errorf("DownloadCSV on an empty CSV = %v, want nil", err)
+	}
+}

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -210,7 +210,7 @@ func (d *Downloader) HandleURL(ctx context.Context, rawURL string) error {
 		if err != nil {
 			return err
 		}
-		return d.downloadArtist(ctx, pages)
+		return d.downloadAlbumCollection(ctx, pages, "albums", "discography", d.Opts.SmartDiscog)
 	case "playlist":
 		pages, err := d.Client.GetPlaylistMeta(ctx, itemID)
 		if err != nil {
@@ -222,7 +222,7 @@ func (d *Downloader) HandleURL(ctx context.Context, rawURL string) error {
 		if err != nil {
 			return err
 		}
-		return d.downloadLabelOrArtist(ctx, pages, "albums", "label")
+		return d.downloadAlbumCollection(ctx, pages, "albums", "label", false)
 	default:
 		return fmt.Errorf("unsupported URL type: %s", urlType)
 	}

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -27,7 +27,9 @@ const (
 	bookletFile = "booklet.pdf"
 )
 
-var qualities = map[int]string{
+// Qualities maps a Qobuz format id to its human label. Exported so the CLI
+// prints the same names the downloader uses.
+var Qualities = map[int]string{
 	5:  "5 - MP3",
 	6:  "6 - 16 bit, 44.1kHz",
 	7:  "7 - 24 bit, <96kHz",

--- a/internal/downloader/helpers.go
+++ b/internal/downloader/helpers.go
@@ -169,16 +169,27 @@ func safeJoin(base, elem string) (string, error) {
 }
 
 func nestedStr(m map[string]interface{}, keys ...string) string {
+	s, _ := walkKeys(m, keys).(string)
+	return s
+}
+
+func nestedFloat(m map[string]interface{}, keys ...string) float64 {
+	v, _ := walkKeys(m, keys).(float64)
+	return v
+}
+
+// walkKeys descends through nested maps, returning nil the moment a level is
+// missing or is not a map.
+func walkKeys(m map[string]interface{}, keys []string) interface{} {
 	var cur interface{} = m
 	for _, k := range keys {
 		mm, ok := cur.(map[string]interface{})
 		if !ok {
-			return ""
+			return nil
 		}
 		cur = mm[k]
 	}
-	s, _ := cur.(string)
-	return s
+	return cur
 }
 
 func releaseYear(meta map[string]interface{}) string {
@@ -194,9 +205,4 @@ func isLocalFile(s string) bool {
 	}
 	_, err := os.Stat(s)
 	return err == nil
-}
-
-func getFloat(m map[string]interface{}, key string) float64 {
-	v, _ := m[key].(float64)
-	return v
 }

--- a/internal/downloader/helpers_test.go
+++ b/internal/downloader/helpers_test.go
@@ -436,27 +436,24 @@ func TestEssenceTitle(t *testing.T) {
 	}
 }
 
-// ---- isAlbumType --------------------------------------------------------
+// ---- isRemaster ---------------------------------------------------------
 
-func TestIsAlbumType(t *testing.T) {
+func TestIsRemaster(t *testing.T) {
 	cases := []struct {
-		albumType string
-		album     map[string]interface{}
-		want      bool
+		album map[string]interface{}
+		want  bool
 	}{
-		{"remaster", map[string]interface{}{"title": "Dark Side (Remastered)", "version": ""}, true},
-		{"remaster", map[string]interface{}{"title": "OK Computer", "version": ""}, false},
-		{"remaster", map[string]interface{}{"title": "OK Computer", "version": "Remastered"}, true},
-		{"extra", map[string]interface{}{"title": "Deluxe Edition", "version": ""}, true},
-		{"extra", map[string]interface{}{"title": "Anniversary Edition", "version": ""}, true},
-		{"extra", map[string]interface{}{"title": "Normal Album", "version": ""}, false},
-		{"extra", map[string]interface{}{"title": "Normal", "version": "Live at MSG"}, true},
-		{"unknown", map[string]interface{}{"title": "Anything", "version": ""}, false},
+		{map[string]interface{}{"title": "Dark Side (Remastered)", "version": ""}, true},
+		{map[string]interface{}{"title": "OK Computer", "version": ""}, false},
+		{map[string]interface{}{"title": "OK Computer", "version": "Remastered"}, true},
+		{map[string]interface{}{"title": "Master of Puppets", "version": ""}, true}, // known false positive
+		{map[string]interface{}{"title": "Deluxe Edition", "version": ""}, false},
+		{map[string]interface{}{"title": "Normal", "version": "Live at MSG"}, false},
+		{map[string]interface{}{}, false},
 	}
 	for _, c := range cases {
-		got := isAlbumType(c.albumType, c.album)
-		if got != c.want {
-			t.Errorf("isAlbumType(%q, %v) = %v, want %v", c.albumType, c.album, got, c.want)
+		if got := isRemaster(c.album); got != c.want {
+			t.Errorf("isRemaster(%v) = %v, want %v", c.album, got, c.want)
 		}
 	}
 }

--- a/internal/downloader/lastfm.go
+++ b/internal/downloader/lastfm.go
@@ -123,7 +123,7 @@ func (d *Downloader) downloadLastFMPlaylist(ctx context.Context, username, listT
 		return err
 	}
 	if len(tracks) == 0 {
-		fmt.Println("\033[33mNo tracks found in Last.fm playlist.\033[0m")
+		fmt.Fprintln(d.termOut(), "\033[33mNo tracks found in Last.fm playlist.\033[0m")
 		return nil
 	}
 	fmt.Fprintf(d.termOut(), "\033[33mFound %d tracks — searching Qobuz...\033[0m\n\n", len(tracks))

--- a/internal/downloader/metadata.go
+++ b/internal/downloader/metadata.go
@@ -7,6 +7,7 @@ package downloader
 // Both are pure-Go implementations with no external dependencies.
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
@@ -67,7 +68,7 @@ func buildFLACTags(track, album map[string]interface{}, isTrack bool) map[string
 		t["TRACKTOTAL"] = fmt.Sprintf("%v", nestedFloat(track, "album", "tracks_count"))
 		t["ALBUM"] = nestedStr(track, "album", "title")
 		t["DATE"] = nestedStr(track, "album", "release_date_original")
-		t["COPYRIGHT"] = formatCopyright(safeGetStr(track, "copyright"))
+		t["COPYRIGHT"] = formatCopyright(nestedStr(track, "copyright"))
 		t["LABEL"] = nestedStr(track, "album", "label", "name")
 	} else {
 		if performer == "" {
@@ -76,7 +77,7 @@ func buildFLACTags(track, album map[string]interface{}, isTrack bool) map[string
 		t["ARTIST"] = performer
 		t["GENRE"] = formatGenres(sliceStrings(album, "", "genres_list"))
 		t["ALBUMARTIST"] = nestedStr(album, "artist", "name")
-		t["TRACKTOTAL"] = fmt.Sprintf("%v", nestedFloat(album, "", "tracks_count"))
+		t["TRACKTOTAL"] = fmt.Sprintf("%v", nestedFloat(album, "tracks_count"))
 		t["ALBUM"] = nestedStr(album, "", "title")
 		if t["ALBUM"] == "" {
 			t["ALBUM"], _ = album["title"].(string)
@@ -84,7 +85,7 @@ func buildFLACTags(track, album map[string]interface{}, isTrack bool) map[string
 		if rd, _ := album["release_date_original"].(string); rd != "" {
 			t["DATE"] = rd
 		}
-		t["COPYRIGHT"] = formatCopyright(safeGetStr(album, "copyright"))
+		t["COPYRIGHT"] = formatCopyright(nestedStr(album, "copyright"))
 		t["LABEL"] = nestedStr(album, "label", "name")
 	}
 
@@ -199,18 +200,14 @@ func buildVorbisComment(tags map[string]string) []byte {
 		size += 4 + len(c)
 	}
 	buf := make([]byte, 0, size)
-	buf = appendU32LE(buf, uint32(len(vendorBytes)))
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(vendorBytes)))
 	buf = append(buf, vendorBytes...)
-	buf = appendU32LE(buf, uint32(len(comments)))
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(comments)))
 	for _, c := range comments {
-		buf = appendU32LE(buf, uint32(len(c)))
+		buf = binary.LittleEndian.AppendUint32(buf, uint32(len(c)))
 		buf = append(buf, c...)
 	}
 	return buf
-}
-
-func appendU32LE(b []byte, v uint32) []byte {
-	return append(b, byte(v), byte(v>>8), byte(v>>16), byte(v>>24))
 }
 
 func buildFLACPictureBlock(imgData []byte) []byte {
@@ -219,23 +216,20 @@ func buildFLACPictureBlock(imgData []byte) []byte {
 	// FLAC picture block layout (all big-endian uint32):
 	// picture_type, mime_length, mime, desc_length, desc,
 	// width, height, color_depth, color_count, data_length, data
+	be := binary.BigEndian
 	buf := make([]byte, 0, 32+len(mimeType)+len(imgData))
-	buf = appendU32BE(buf, 3) // Front cover
-	buf = appendU32BE(buf, uint32(len(mimeType)))
+	buf = be.AppendUint32(buf, 3) // Front cover
+	buf = be.AppendUint32(buf, uint32(len(mimeType)))
 	buf = append(buf, []byte(mimeType)...)
-	buf = appendU32BE(buf, uint32(len(desc)))
+	buf = be.AppendUint32(buf, uint32(len(desc)))
 	buf = append(buf, []byte(desc)...)
-	buf = appendU32BE(buf, 0) // width (unknown)
-	buf = appendU32BE(buf, 0) // height
-	buf = appendU32BE(buf, 0) // color depth
-	buf = appendU32BE(buf, 0) // color count
-	buf = appendU32BE(buf, uint32(len(imgData)))
+	buf = be.AppendUint32(buf, 0) // width (unknown)
+	buf = be.AppendUint32(buf, 0) // height
+	buf = be.AppendUint32(buf, 0) // color depth
+	buf = be.AppendUint32(buf, 0) // color count
+	buf = be.AppendUint32(buf, uint32(len(imgData)))
 	buf = append(buf, imgData...)
 	return buf
-}
-
-func appendU32BE(b []byte, v uint32) []byte {
-	return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
 }
 
 // readCover loads the cover image next to (or one level above) dir.
@@ -286,7 +280,7 @@ func buildMP3Tags(track, album map[string]interface{}, isTrack bool) map[string]
 		t["TPE2"] = nestedStr(track, "album", "artist", "name")
 		t["TALB"] = nestedStr(track, "album", "title")
 		t["TDRC"] = nestedStr(track, "album", "release_date_original")
-		t["TCOP"] = formatCopyright(safeGetStr(track, "copyright"))
+		t["TCOP"] = formatCopyright(nestedStr(track, "copyright"))
 		t["TPUB"] = nestedStr(track, "album", "label", "name")
 		trackTotal = fmt.Sprintf("%v", nestedFloat(track, "album", "tracks_count"))
 	} else {
@@ -301,9 +295,9 @@ func buildMP3Tags(track, album map[string]interface{}, isTrack bool) map[string]
 		if v, ok := album["release_date_original"].(string); ok {
 			t["TDRC"] = v
 		}
-		t["TCOP"] = formatCopyright(safeGetStr(album, "copyright"))
+		t["TCOP"] = formatCopyright(nestedStr(album, "copyright"))
 		t["TPUB"] = nestedStr(album, "label", "name")
-		trackTotal = fmt.Sprintf("%v", getFloat(album, "tracks_count"))
+		trackTotal = fmt.Sprintf("%v", nestedFloat(album, "tracks_count"))
 	}
 	t["TPE1"] = performer
 	if t["TDRC"] != "" && len(t["TDRC"]) >= 4 {
@@ -504,23 +498,4 @@ func sliceStrings(m map[string]interface{}, subKey, key string) []string {
 		}
 	}
 	return result
-}
-
-func safeGetStr(m map[string]interface{}, key string) string {
-	v, _ := m[key].(string)
-	return v
-}
-
-func nestedFloat(m map[string]interface{}, subKey, key string) float64 {
-	var src interface{} = m
-	if subKey != "" {
-		sub, _ := m[subKey].(map[string]interface{})
-		if sub == nil {
-			return 0
-		}
-		src = sub
-	}
-	mm, _ := src.(map[string]interface{})
-	v, _ := mm[key].(float64)
-	return v
 }

--- a/internal/downloader/metadata.go
+++ b/internal/downloader/metadata.go
@@ -11,23 +11,33 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"unicode/utf16"
 )
 
 // ---- FLAC tagging ----
 
-// tagFLAC writes Vorbis Comment metadata to a FLAC file,
-// then renames tmpFile → finalFile.
+// FLAC metadata block types (the ones we read or replace).
+const (
+	typeStreamInfo    = 0
+	typeVorbisComment = 4
+	typePicture       = 6
+)
+
+// tagFLAC writes Vorbis Comment metadata — and, when embedArt is set, the
+// cover art — to a FLAC file in a single rewrite, then renames tmpFile →
+// finalFile.
 func tagFLAC(tmpFile, coverDir, finalFile string, track, album map[string]interface{}, isTrack, embedArt bool) error {
-	tags := buildFLACTags(track, album, isTrack)
-	if err := writeFLACTags(tmpFile, tags); err != nil {
-		return err
-	}
+	var cover []byte
 	if embedArt {
-		if err := embedFLACCover(tmpFile, coverDir); err != nil {
+		var err error
+		if cover, err = readCover(coverDir); err != nil {
 			fmt.Printf("\033[33mWarning: could not embed cover: %v\033[0m\n", err)
 		}
+	}
+	if err := writeFLACMeta(tmpFile, buildFLACTags(track, album, isTrack), cover); err != nil {
+		return err
 	}
 	return os.Rename(tmpFile, finalFile)
 }
@@ -81,36 +91,57 @@ func buildFLACTags(track, album map[string]interface{}, isTrack bool) map[string
 	return t
 }
 
-// writeFLACTags reads a FLAC file, replaces/adds a VORBIS_COMMENT block, and writes back.
-// FLAC format: 4-byte magic, then a sequence of metadata blocks.
-// Each block: 1-byte type+last_flag, 3-byte length, then data.
-func writeFLACTags(path string, tags map[string]string) error {
-	data, err := os.ReadFile(path)
+// flacBlock is a single FLAC metadata block. The last-block flag is not stored
+// — writeFLAC recomputes it from the position in the slice.
+type flacBlock struct {
+	blockType byte
+	data      []byte
+}
+
+// writeFLACMeta rewrites the metadata of a FLAC file in one pass: the
+// VORBIS_COMMENT block is replaced with tags, and when cover is non-nil the
+// existing PICTURE blocks are replaced with it. A nil cover leaves whatever
+// artwork the file already carries untouched.
+func writeFLACMeta(path string, tags map[string]string, cover []byte) error {
+	drop := []byte{typeVorbisComment}
+	if cover != nil {
+		drop = append(drop, typePicture)
+	}
+	blocks, audio, err := splitFLAC(path, drop...)
 	if err != nil {
 		return err
 	}
+
+	// Vorbis Comment belongs right after STREAMINFO; without one, it goes last.
+	vc := flacBlock{typeVorbisComment, buildVorbisComment(tags)}
+	if i := slices.IndexFunc(blocks, func(b flacBlock) bool { return b.blockType == typeStreamInfo }); i >= 0 {
+		blocks = slices.Insert(blocks, i+1, vc)
+	} else {
+		blocks = append(blocks, vc)
+	}
+
+	if cover != nil {
+		blocks = append(blocks, flacBlock{typePicture, buildFLACPictureBlock(cover)})
+	}
+	return writeFLAC(path, blocks, audio)
+}
+
+// splitFLAC parses a FLAC file into its metadata blocks and the audio data
+// that follows, discarding every block whose type appears in drop.
+// FLAC format: 4-byte magic, then a sequence of metadata blocks.
+// Each block: 1-byte type+last_flag, 3-byte length, then data.
+func splitFLAC(path string, drop ...byte) ([]flacBlock, []byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
 	if len(data) < 4 || string(data[:4]) != "fLaC" {
-		return fmt.Errorf("not a FLAC file: %s", path)
+		return nil, nil, fmt.Errorf("not a FLAC file: %s", path)
 	}
 
-	// Parse existing blocks, removing any existing VORBIS_COMMENT (type 4)
-	const (
-		typeStreamInfo    = 0
-		typeVorbisComment = 4
-		typePicture       = 6
-	)
-
-	type block struct {
-		blockType byte
-		data      []byte
-	}
-
-	var blocks []block
+	var blocks []flacBlock
 	pos := 4
-	for pos < len(data) {
-		if pos+4 > len(data) {
-			break
-		}
+	for pos+4 <= len(data) {
 		header := data[pos]
 		isLast := (header & 0x80) != 0
 		bType := header & 0x7F
@@ -119,42 +150,24 @@ func writeFLACTags(path string, tags map[string]string) error {
 		if pos+length > len(data) {
 			break
 		}
-		blockData := data[pos : pos+length]
-		pos += length
-
-		if bType != typeVorbisComment {
-			blocks = append(blocks, block{bType, blockData})
+		if !slices.Contains(drop, bType) {
+			blocks = append(blocks, flacBlock{bType, data[pos : pos+length]})
 		}
+		pos += length
 		if isLast {
 			break
 		}
 	}
-	audioData := data[pos:]
+	return blocks, data[pos:], nil
+}
 
-	// Build new Vorbis Comment block
-	vcData := buildVorbisComment(tags)
-
-	// Re-assemble: insert VC block after STREAMINFO
-	var newBlocks []block
-	inserted := false
-	for _, b := range blocks {
-		newBlocks = append(newBlocks, b)
-		if b.blockType == typeStreamInfo && !inserted {
-			newBlocks = append(newBlocks, block{typeVorbisComment, vcData})
-			inserted = true
-		}
-	}
-	if !inserted {
-		newBlocks = append(newBlocks, block{typeVorbisComment, vcData})
-	}
-
-	// Encode blocks
-	var out []byte
-	out = append(out, 'f', 'L', 'a', 'C')
-	for i, b := range newBlocks {
-		isLast := i == len(newBlocks)-1
+// writeFLAC encodes blocks followed by audio back to path, flagging the last
+// metadata block as required by the format.
+func writeFLAC(path string, blocks []flacBlock, audio []byte) error {
+	out := []byte("fLaC")
+	for i, b := range blocks {
 		header := b.blockType
-		if isLast {
+		if i == len(blocks)-1 {
 			header |= 0x80
 		}
 		length := len(b.data)
@@ -162,8 +175,7 @@ func writeFLACTags(path string, tags map[string]string) error {
 			byte(length>>16), byte(length>>8), byte(length))
 		out = append(out, b.data...)
 	}
-	out = append(out, audioData...)
-
+	out = append(out, audio...)
 	return os.WriteFile(path, out, 0644)
 }
 
@@ -201,73 +213,6 @@ func appendU32LE(b []byte, v uint32) []byte {
 	return append(b, byte(v), byte(v>>8), byte(v>>16), byte(v>>24))
 }
 
-func embedFLACCover(flacPath, coverDir string) error {
-	coverPath := findCover(coverDir)
-	if coverPath == "" {
-		return fmt.Errorf("cover not found")
-	}
-	imgData, err := os.ReadFile(coverPath)
-	if err != nil {
-		return err
-	}
-
-	const typePicture = 6
-	picBlock := buildFLACPictureBlock(imgData)
-	data, err := os.ReadFile(flacPath)
-	if err != nil {
-		return err
-	}
-	if len(data) < 4 {
-		return fmt.Errorf("bad FLAC")
-	}
-
-	type block struct {
-		blockType byte
-		data      []byte
-	}
-	var blocks []block
-	pos := 4
-	for pos < len(data) {
-		if pos+4 > len(data) {
-			break
-		}
-		header := data[pos]
-		isLast := (header & 0x80) != 0
-		bType := header & 0x7F
-		length := int(data[pos+1])<<16 | int(data[pos+2])<<8 | int(data[pos+3])
-		pos += 4
-		if pos+length > len(data) {
-			break
-		}
-		blockData := data[pos : pos+length]
-		pos += length
-		if bType != typePicture { // remove old pictures
-			blocks = append(blocks, block{bType, blockData})
-		}
-		if isLast {
-			break
-		}
-	}
-	audioData := data[pos:]
-
-	blocks = append(blocks, block{typePicture, picBlock})
-
-	var out []byte
-	out = append(out, 'f', 'L', 'a', 'C')
-	for i, b := range blocks {
-		isLast := i == len(blocks)-1
-		header := b.blockType
-		if isLast {
-			header |= 0x80
-		}
-		length := len(b.data)
-		out = append(out, header, byte(length>>16), byte(length>>8), byte(length))
-		out = append(out, b.data...)
-	}
-	out = append(out, audioData...)
-	return os.WriteFile(flacPath, out, 0644)
-}
-
 func buildFLACPictureBlock(imgData []byte) []byte {
 	mimeType := "image/jpeg"
 	desc := ""
@@ -291,6 +236,15 @@ func buildFLACPictureBlock(imgData []byte) []byte {
 
 func appendU32BE(b []byte, v uint32) []byte {
 	return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+}
+
+// readCover loads the cover image next to (or one level above) dir.
+func readCover(dir string) ([]byte, error) {
+	path := findCover(dir)
+	if path == "" {
+		return nil, fmt.Errorf("cover not found")
+	}
+	return os.ReadFile(path)
 }
 
 func findCover(dir string) string {
@@ -381,12 +335,8 @@ func writeID3v23(path string, tags map[string]string, embedArt bool, coverDir st
 	}
 
 	if embedArt {
-		coverPath := findCover(coverDir)
-		if coverPath != "" {
-			if imgData, err := os.ReadFile(coverPath); err == nil {
-				frame := buildAPICFrame(imgData)
-				frames = append(frames, frame...)
-			}
+		if imgData, err := readCover(coverDir); err == nil {
+			frames = append(frames, buildAPICFrame(imgData)...)
 		}
 	}
 

--- a/internal/downloader/metadata.go
+++ b/internal/downloader/metadata.go
@@ -29,12 +29,16 @@ const (
 // tagFLAC writes Vorbis Comment metadata — and, when embedArt is set, the
 // cover art — to a FLAC file in a single rewrite, then renames tmpFile →
 // finalFile.
-func tagFLAC(tmpFile, coverDir, finalFile string, track, album map[string]interface{}, isTrack, embedArt bool) error {
+//
+// w is where the missing-cover warning goes. It must be the downloader's
+// termOut(), never os.Stdout: this runs from the worker pool with progress
+// bars live, and under the TUI nothing may reach the terminal at all.
+func tagFLAC(w io.Writer, tmpFile, coverDir, finalFile string, track, album map[string]interface{}, isTrack, embedArt bool) error {
 	var cover []byte
 	if embedArt {
 		var err error
 		if cover, err = readCover(coverDir); err != nil {
-			fmt.Printf("\033[33mWarning: could not embed cover: %v\033[0m\n", err)
+			fmt.Fprintf(w, "\033[33mWarning: could not embed cover: %v\033[0m\n", err)
 		}
 	}
 	if err := writeFLACMeta(tmpFile, buildFLACTags(track, album, isTrack), cover); err != nil {

--- a/internal/downloader/metadata_test.go
+++ b/internal/downloader/metadata_test.go
@@ -1,11 +1,92 @@
 package downloader
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// Tags and cover art are written in a single rewrite: the Vorbis Comment must
+// land right after STREAMINFO, the stale PICTURE block must be replaced (not
+// duplicated), and the audio data must survive untouched.
+func TestWriteFLACMeta_TagsAndCoverInOnePass(t *testing.T) {
+	// A PADDING block sits between STREAMINFO and PICTURE so that inserting the
+	// Vorbis Comment after STREAMINFO is distinguishable from appending it at
+	// the end — with a single block both would produce the same file.
+	flac := append([]byte("fLaC"), 0x00, 0x00, 0x00, 0x22) // STREAMINFO, not last, len 34
+	flac = append(flac, make([]byte, 34)...)
+	flac = append(flac, 0x01, 0x00, 0x00, 0x02, 0x00, 0x00) // PADDING, not last, len 2
+	flac = append(flac, 0x86, 0x00, 0x00, 0x03)             // PICTURE, last, len 3
+	flac = append(flac, "old"...)
+	audio := []byte{0xff, 0xf8, 0x00, 0x00}
+	flac = append(flac, audio...)
+
+	tmp := tempFile(t, "*.flac")
+	if err := os.WriteFile(tmp, flac, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cover := []byte("JPEGDATA")
+	if err := writeFLACMeta(tmp, map[string]string{"TITLE": "One Pass"}, cover); err != nil {
+		t.Fatalf("writeFLACMeta: %v", err)
+	}
+
+	out, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocks, tail := walkFLAC(t, out)
+
+	var types []byte
+	for _, b := range blocks {
+		types = append(types, b.blockType)
+	}
+	const typePadding = 1
+	if want := []byte{typeStreamInfo, typeVorbisComment, typePadding, typePicture}; !bytes.Equal(types, want) {
+		t.Fatalf("block types = %v, want %v", types, want)
+	}
+	if !strings.Contains(string(blocks[1].data), "TITLE=One Pass") {
+		t.Error("TITLE tag missing from Vorbis Comment block")
+	}
+	if !bytes.HasSuffix(blocks[3].data, cover) {
+		t.Error("new cover not found in PICTURE block")
+	}
+	if bytes.Contains(blocks[3].data, []byte("old")) {
+		t.Error("stale PICTURE block was not replaced")
+	}
+	if !bytes.Equal(tail, audio) {
+		t.Errorf("audio data = %q, want %q", tail, audio)
+	}
+}
+
+// walkFLAC parses an encoded FLAC into its metadata blocks and trailing audio,
+// failing the test unless exactly the final block carries the last-block flag.
+func walkFLAC(t *testing.T, data []byte) ([]flacBlock, []byte) {
+	t.Helper()
+	if len(data) < 4 || string(data[:4]) != "fLaC" {
+		t.Fatal("output is not a FLAC file")
+	}
+	var blocks []flacBlock
+	pos := 4
+	for pos+4 <= len(data) {
+		isLast := data[pos]&0x80 != 0
+		bType := data[pos] & 0x7F
+		n := int(data[pos+1])<<16 | int(data[pos+2])<<8 | int(data[pos+3])
+		pos += 4
+		if pos+n > len(data) {
+			t.Fatalf("block %d overruns end of file", len(blocks))
+		}
+		blocks = append(blocks, flacBlock{bType, data[pos : pos+n]})
+		pos += n
+		if isLast {
+			return blocks, data[pos:]
+		}
+	}
+	t.Fatal("no block carries the last-block flag")
+	return nil, nil
+}
 
 // ---- FLAC tagging tests ----
 
@@ -24,8 +105,8 @@ func TestWriteFLACTags_RoundTrip(t *testing.T) {
 		"TRACKNUMBER": "3",
 		"DATE":        "2024-04-01",
 	}
-	if err := writeFLACTags(tmp, tags); err != nil {
-		t.Fatalf("writeFLACTags: %v", err)
+	if err := writeFLACMeta(tmp, tags, nil); err != nil {
+		t.Fatalf("writeFLACMeta: %v", err)
 	}
 
 	// Read back and verify the Vorbis Comment block is present
@@ -73,7 +154,7 @@ func TestWriteFLACTags_RoundTrip(t *testing.T) {
 func TestWriteFLACTags_NotFLAC(t *testing.T) {
 	tmp := tempFile(t, "*.flac")
 	os.WriteFile(tmp, []byte("not a flac file"), 0644)
-	err := writeFLACTags(tmp, map[string]string{"TITLE": "x"})
+	err := writeFLACMeta(tmp, map[string]string{"TITLE": "x"}, nil)
 	if err == nil {
 		t.Error("expected error for non-FLAC file")
 	}

--- a/internal/downloader/metadata_test.go
+++ b/internal/downloader/metadata_test.go
@@ -2,6 +2,7 @@ package downloader
 
 import (
 	"bytes"
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"strings"
@@ -541,3 +542,36 @@ func containsBytes(data, sub []byte) bool {
 
 // suppress unused import
 var _ = filepath.Join
+
+// TestBuildFLACPictureBlock pins the field layout, and specifically that every
+// uint32 is big-endian — the FLAC spec's byte order, and the opposite of the
+// Vorbis Comment block right next to it in the same file.
+func TestBuildFLACPictureBlock(t *testing.T) {
+	img := bytes.Repeat([]byte{0xAB}, 300) // >255 so the length bytes disagree LE vs BE
+	b := buildFLACPictureBlock(img)
+
+	be := binary.BigEndian
+	if got := be.Uint32(b[0:4]); got != 3 {
+		t.Errorf("picture_type = %d, want 3 (front cover)", got)
+	}
+	mimeLen := be.Uint32(b[4:8])
+	if mimeLen != uint32(len("image/jpeg")) {
+		t.Fatalf("mime_length = %d, want %d", mimeLen, len("image/jpeg"))
+	}
+	if got := string(b[8 : 8+mimeLen]); got != "image/jpeg" {
+		t.Errorf("mime = %q, want %q", got, "image/jpeg")
+	}
+
+	// desc_length, then four zeroed image properties, then data_length.
+	p := 8 + mimeLen
+	if got := be.Uint32(b[p : p+4]); got != 0 {
+		t.Errorf("desc_length = %d, want 0", got)
+	}
+	p += 4 + 16 // empty desc + width/height/depth/count
+	if got := be.Uint32(b[p : p+4]); got != uint32(len(img)) {
+		t.Errorf("data_length = %d, want %d", got, len(img))
+	}
+	if got := b[p+4:]; !bytes.Equal(got, img) {
+		t.Errorf("image payload truncated: %d bytes, want %d", len(got), len(img))
+	}
+}

--- a/internal/downloader/search.go
+++ b/internal/downloader/search.go
@@ -59,7 +59,7 @@ func Search(ctx context.Context, client *api.Client, itemType, query string, lim
 		}
 		text := renderFormat(format, m)
 		if requiresExtra {
-			dur := formatDuration(int(getFloat(m, "duration")))
+			dur := formatDuration(int(nestedFloat(m, "duration")))
 			hires := "LOSSLESS"
 			if b, _ := m["hires_streamable"].(bool); b {
 				hires = "HI-RES"
@@ -75,9 +75,11 @@ func Search(ctx context.Context, client *api.Client, itemType, query string, lim
 	return results, nil
 }
 
+// Simple key substitution: {key} → m[key], {obj[key]} → m[obj][key].
+// Package-level so it is not recompiled once per search result.
+var reKey = regexp.MustCompile(`\{(\w+)(?:\[(\w+)\])?\}`)
+
 func renderFormat(format string, m map[string]interface{}) string {
-	// Simple key substitution: {key} → m[key], {obj[key]} → m[obj][key]
-	reKey := regexp.MustCompile(`\{(\w+)(?:\[(\w+)\])?\}`)
 	return reKey.ReplaceAllStringFunc(format, func(match string) string {
 		parts := reKey.FindStringSubmatch(match)
 		if parts[2] != "" {

--- a/internal/downloader/track.go
+++ b/internal/downloader/track.go
@@ -257,7 +257,7 @@ func (d *Downloader) fallbackQuality(ctx context.Context, trackID string) (map[s
 		}
 		info, err := d.Client.GetTrackURL(ctx, trackID, q, "")
 		if err == nil {
-			fmt.Fprintf(d.termOut(), "\033[33mQuality fallback to %s for track %s\033[0m\n", qualities[q], trackID)
+			fmt.Fprintf(d.termOut(), "\033[33mQuality fallback to %s for track %s\033[0m\n", Qualities[q], trackID)
 			return info, nil
 		}
 	}

--- a/internal/downloader/track.go
+++ b/internal/downloader/track.go
@@ -240,7 +240,7 @@ func (d *Downloader) downloadAndTag(
 			os.Rename(tmpFile, finalFile)
 		}
 	} else {
-		if err := tagFLAC(tmpFile, dir, finalFile, trackMeta, albumMeta, isTrack, d.Opts.EmbedArt); err != nil {
+		if err := tagFLAC(d.termOut(), tmpFile, dir, finalFile, trackMeta, albumMeta, isTrack, d.Opts.EmbedArt); err != nil {
 			fmt.Fprintf(d.termOut(), "\033[31mWarning: could not tag %s: %v\033[0m\n", filepath.Base(finalFile), err)
 			os.Rename(tmpFile, finalFile)
 		}

--- a/internal/downloader/tui_test.go
+++ b/internal/downloader/tui_test.go
@@ -3,6 +3,7 @@ package downloader
 import (
 	"context"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -87,5 +88,47 @@ func TestTermOutDiscardsUnderTUI(t *testing.T) {
 	}
 	if d.termOut() == os.Stdout {
 		t.Error("with a TUI active, termOut must not write to stdout")
+	}
+}
+
+// TestNoDirectStdoutWrites guards the invariant that TestTermOutDiscardsUnderTUI
+// cannot: that one proves termOut() returns io.Discard under the TUI, this one
+// proves the package actually goes through it.
+//
+// It found three live leaks when it was written — tagFLAC's missing-cover
+// warning plus the empty-playlist notices in csvbatch.go and lastfm.go — each
+// sitting a couple of lines from code that did use termOut(). A bare fmt.Printf
+// corrupts mpb's redraw and, under the TUI, paints over the alt screen.
+//
+// Static on purpose: reaching these branches for real needs a live download.
+func TestNoDirectStdoutWrites(t *testing.T) {
+	// interactive.go is the `fun` REPL: it owns the terminal and never runs
+	// with bars or the TUI up. oauth.go prints only with the terminal
+	// released, which is what makes reusing the CLI flow correct.
+	allowed := map[string]bool{"interactive.go": true, "oauth.go": true}
+
+	reDirect := regexp.MustCompile(`fmt\.Print(f|ln)?\(|fmt\.Fprint(f|ln)?\(os\.Stdout`)
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	scanned := 0
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") || allowed[name] {
+			continue
+		}
+		src, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		scanned++
+		for _, m := range reDirect.FindAllString(string(src), -1) {
+			t.Errorf("%s writes straight to stdout with %s — use d.termOut(), or take an io.Writer parameter", name, m)
+		}
+	}
+	if scanned == 0 {
+		t.Fatal("scanned no files — the walk is broken")
 	}
 }

--- a/internal/downloader/tui_test.go
+++ b/internal/downloader/tui_test.go
@@ -107,7 +107,9 @@ func TestNoDirectStdoutWrites(t *testing.T) {
 	// released, which is what makes reusing the CLI flow correct.
 	allowed := map[string]bool{"interactive.go": true, "oauth.go": true}
 
-	reDirect := regexp.MustCompile(`fmt\.Print(f|ln)?\(|fmt\.Fprint(f|ln)?\(os\.Stdout`)
+	// os.Stderr counts too: the alt screen swallows both streams the same way,
+	// and stderr is where the CSV parse warnings used to go.
+	reDirect := regexp.MustCompile(`fmt\.Print(f|ln)?\(|fmt\.Fprint(f|ln)?\(os\.(Stdout|Stderr)`)
 
 	entries, err := os.ReadDir(".")
 	if err != nil {

--- a/internal/ui/lang.go
+++ b/internal/ui/lang.go
@@ -94,7 +94,24 @@ var es = map[string]string{
 	"back":          "volver",
 	"quit":          "salir",
 
-	// download screen badges
-	"BATCH": "LOTE",
-	"DONE":  "LISTO",
+	// download screen badges and footer
+	"BATCH":            "LOTE",
+	"DONE":             "LISTO",
+	"%d done":          "%d completadas",
+	"%d failed":        "%d errores",
+	"%d active":        "%d activas",
+	"Ctrl+C to cancel": "Ctrl+C cancelar",
+
+	// picker
+	"  (empty)": "  (vacío)",
+
+	// backend status messages (cmd/qobuz-dl/tui_cmd.go). Errors from the
+	// backend stay in English, like every other error in the program.
+	"signed in successfully":        "sesión iniciada",
+	"CSV import finished":           "importación CSV terminada",
+	"scanning %s…":                  "escaneando %s…",
+	"%d audio files found":          "%d archivos de audio encontrados",
+	"no audio found in that folder": "no se encontró audio en esa carpeta",
+	"lyrics: %d new · %d already there · %d without a match": "letras: %d nuevas · %d ya estaban · %d sin resultado",
+	"could not read the settings":                            "no se pudo leer la configuración",
 }

--- a/internal/ui/lang_test.go
+++ b/internal/ui/lang_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -81,10 +82,12 @@ func TestSpanishHasNoOrphanKeys(t *testing.T) {
 func TestNoSpanishLeftInSources(t *testing.T) {
 	src := readUISources(t)
 
-	// Spanish-only characters. Accented vowels alone would also match loan
-	// words, but ñ/¿/¡ plus the inverted marks are unambiguous enough, and the
-	// menu table is covered exhaustively by the test above.
-	reSpanish := regexp.MustCompile(`"[^"]*[ñÑ¿¡][^"]*"`)
+	// Characters that do not occur in the English this program writes. Accented
+	// vowels are included: in principle they match loan words, in practice this
+	// codebase has none, and leaving them out let "(vacío)" sit in widgets.go
+	// unnoticed. Spanish with no accent at all ("%d completadas") still slips
+	// through here — TestEnglishRenderStaysEnglish is what catches that.
+	reSpanish := regexp.MustCompile(`"[^"]*[ñÑ¿¡áéíóúÁÉÍÓÚ][^"]*"`)
 	if m := reSpanish.FindAllString(src, -1); m != nil {
 		t.Errorf("Spanish literals outside lang.go: %v", m)
 	}
@@ -92,22 +95,39 @@ func TestNoSpanishLeftInSources(t *testing.T) {
 
 func quoteForGo(s string) string { return `"` + s + `"` }
 
-// readUISources returns the package's non-test, non-lang.go sources.
+// readUISources returns every non-test Go source that can put text on the TUI
+// screen: this package plus cmd/qobuz-dl, where the Backend implementation
+// builds its own status messages. lang.go is excluded — it is the one place
+// Spanish belongs.
+//
+// Read by directory rather than from a list of filenames: a list silently
+// stops covering any file added after it was written, which is how the backend
+// messages went unchecked in the first place.
 func readUISources(t *testing.T) string {
 	t.Helper()
 	var b strings.Builder
-	for _, f := range []string{"shell.go", "model.go", "widgets.go", "handle.go", "styles.go", "backend.go"} {
-		b.WriteString(readFile(t, f))
-		b.WriteString("\n")
+	for _, dir := range []string{".", filepath.Join("..", "..", "cmd", "qobuz-dl")} {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read dir %s: %v", dir, err)
+		}
+		for _, e := range entries {
+			name := e.Name()
+			if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") || name == "lang.go" {
+				continue
+			}
+			b.WriteString(readFile(t, filepath.Join(dir, name)))
+			b.WriteString("\n")
+		}
 	}
 	return b.String()
 }
 
-func readFile(t *testing.T, name string) string {
+func readFile(t *testing.T, path string) string {
 	t.Helper()
-	b, err := os.ReadFile(name)
+	b, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("read %s: %v", name, err)
+		t.Fatalf("read %s: %v", path, err)
 	}
 	return string(b)
 }
@@ -146,3 +166,40 @@ func TestMenuRendersFullySpanish(t *testing.T) {
 var reANSI = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 
 func stripANSI(s string) string { return reANSI.ReplaceAllString(s, "") }
+
+// TestEnglishRenderStaysEnglish is the counterpart to the test above: it walks
+// the screens in English and fails if any Spanish text shows up.
+//
+// This is the only check that sees Spanish carrying no distinctive character.
+// "%d completadas" and "Ctrl+C cancelar" sat hardcoded in viewFooter through
+// every other test in this file: the table tests only look at the table, and
+// the source scan keys on ñ/¿/¡/accents, none of which those two contain.
+// A hardcoded string renders identically in both languages — that is the
+// signal, and it needs no word list.
+func TestEnglishRenderStaysEnglish(t *testing.T) {
+	SetLang("")
+	t.Cleanup(func() { SetLang("") })
+
+	m := Model{
+		done:   3,
+		failed: 2,
+		tracks: []trackEntry{{state: stateActive}, {state: stateDone}},
+	}
+	p := newPicker(nil, false)
+	rendered := stripANSI(m.viewFooter() + "\n" + p.view(40))
+
+	for key, val := range es {
+		if val == key {
+			continue
+		}
+		// Compare on the literal part: "%d completadas" renders as "3 completadas".
+		frag := strings.TrimSpace(strings.ReplaceAll(val, "%d", ""))
+		if frag == "" {
+			continue
+		}
+		if strings.Contains(rendered, frag) {
+			t.Errorf("English render contains Spanish %q (key %q) — that string is hardcoded, not translated:\n%s",
+				frag, key, rendered)
+		}
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -384,14 +384,14 @@ func (m Model) viewFooter() string {
 			active++
 		}
 	}
-	parts := []string{sDim.Render(fmt.Sprintf("%d completadas", m.done))}
+	parts := []string{sDim.Render(fmt.Sprintf(T("%d done"), m.done))}
 	if m.failed > 0 {
-		parts = append(parts, sRed.Render(fmt.Sprintf("%d errores", m.failed)))
+		parts = append(parts, sRed.Render(fmt.Sprintf(T("%d failed"), m.failed)))
 	}
 	if active > 0 {
-		parts = append(parts, sBlue.Render(fmt.Sprintf("%d activas", active)))
+		parts = append(parts, sBlue.Render(fmt.Sprintf(T("%d active"), active)))
 	}
-	parts = append(parts, sDim.Render("Ctrl+C cancelar"))
+	parts = append(parts, sDim.Render(T("Ctrl+C to cancel")))
 	return "  " + strings.Join(parts, sDim.Render("  ·  "))
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -270,14 +270,7 @@ func (m Model) viewHeader(w int) string {
 
 	inner := brand
 	if meta != "" {
-		brandW := lipgloss.Width(brand)
-		metaW := lipgloss.Width(meta)
-		pad := w - 6 - brandW - metaW
-		if pad > 0 {
-			inner += strings.Repeat(" ", pad) + meta
-		} else {
-			inner += "  " + meta
-		}
+		inner = rightAlign(brand, meta, w-6)
 	}
 
 	return lipgloss.NewStyle().
@@ -337,23 +330,9 @@ func (m Model) viewTrack(e trackEntry, w int) string {
 	case stateDone:
 		badge := sBadgeDone.Render(T("DONE"))
 		size := sDim.Render(fmtBytes(e.current))
-		rightPart := badge + " " + size
-		pad := w - lipgloss.Width(firstLine) - lipgloss.Width(rightPart) - 1
-		if pad > 0 {
-			firstLine += strings.Repeat(" ", pad)
-		} else {
-			firstLine += " "
-		}
-		firstLine += rightPart
+		firstLine = rightAlign(firstLine, badge+" "+size, w-1)
 	case stateFailed:
-		badge := sBadgeErr.Render("ERROR")
-		pad := w - lipgloss.Width(firstLine) - lipgloss.Width(badge) - 1
-		if pad > 0 {
-			firstLine += strings.Repeat(" ", pad)
-		} else {
-			firstLine += " "
-		}
-		firstLine += badge
+		firstLine = rightAlign(firstLine, sBadgeErr.Render("ERROR"), w-1)
 	}
 
 	lines := []string{firstLine}

--- a/internal/ui/shell.go
+++ b/internal/ui/shell.go
@@ -484,16 +484,12 @@ func (s *Shell) viewHeader(w int) string {
 	}
 
 	right := session + sFaint.Render("  │  ") + queue
-	pad := w - 6 - lipgloss.Width(title) - lipgloss.Width(right)
-	if pad < 1 {
-		pad = 1
-	}
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(cFaint).
 		Padding(0, 1).
 		Width(w - 2).
-		Render(title + strings.Repeat(" ", pad) + right)
+		Render(rightAlign(title, right, w-6))
 }
 
 func (s *Shell) viewMenu(w int) string {
@@ -514,11 +510,7 @@ func (s *Shell) viewMenu(w int) string {
 			if m.hint != "" {
 				text += "  ·  " + T(m.hint)
 			}
-			text = truncate(text, w-6)
-			pad := w - 4 - lipgloss.Width(text)
-			if pad > 0 {
-				text += strings.Repeat(" ", pad)
-			}
+			text = rightAlign(truncate(text, w-6), "", w-4)
 			b.WriteString("  " + sSelected.Render(text) + "\n")
 			continue
 		}

--- a/internal/ui/shell_test.go
+++ b/internal/ui/shell_test.go
@@ -322,3 +322,24 @@ func TestMenuTableIsWellFormed(t *testing.T) {
 		seen[m.act] = true
 	}
 }
+
+// ---- rightAlign ---------------------------------------------------------
+
+func TestRightAlign(t *testing.T) {
+	cases := []struct {
+		left, right string
+		w           int
+		want        string
+	}{
+		{"ab", "cd", 10, "ab      cd"},
+		{"ab", "", 6, "ab    "},
+		{"abc", "def", 6, "abc def"},     // overflow: one space, never zero
+		{"abcd", "efgh", 4, "abcd efgh"}, // no room at all: still separated
+		{"é", "ñ", 5, "é   ñ"},           // width is measured in cells, not bytes
+	}
+	for _, c := range cases {
+		if got := rightAlign(c.left, c.right, c.w); got != c.want {
+			t.Errorf("rightAlign(%q, %q, %d) = %q, want %q", c.left, c.right, c.w, got, c.want)
+		}
+	}
+}

--- a/internal/ui/widgets.go
+++ b/internal/ui/widgets.go
@@ -135,6 +135,16 @@ func (p *picker) view(width int) string {
 	return b.String()
 }
 
+// rightAlign packs left and right onto one line of width w, pushing right to
+// the far edge and keeping at least one space between them when they overflow.
+func rightAlign(left, right string, w int) string {
+	pad := w - lipgloss.Width(left) - lipgloss.Width(right)
+	if pad < 1 {
+		pad = 1
+	}
+	return left + strings.Repeat(" ", pad) + right
+}
+
 func truncate(s string, width int) string {
 	if width < 4 {
 		width = 4

--- a/internal/ui/widgets.go
+++ b/internal/ui/widgets.go
@@ -105,7 +105,7 @@ func (p *picker) selection() []int {
 
 func (p *picker) view(width int) string {
 	if len(p.rows) == 0 {
-		return sDim.Render("  (vacío)")
+		return sDim.Render(T("  (empty)"))
 	}
 
 	var b strings.Builder


### PR DESCRIPTION
Cierra el backlog de `/ponytail-audit` sobre v1.5.0 y, de paso, dos bugs que salieron
al mirar de cerca el TUI.

**−129 líneas de producción** (286 insertadas, 415 borradas). Los tests suben +445, casi
todo por cinco checks nuevos que se explican abajo. Cero dependencias añadidas o quitadas.

## Auditoría de sobreingeniería (15 hallazgos)

| Commit | Qué |
|---|---|
| `ec3b40a` | `writeFLACTags` y `embedFLACCover` compartían 55 líneas → `splitFLAC`/`writeFLAC`/`writeFLACMeta`. `tagFLAC` pasa de 4 pasadas sobre el fichero a 1 lectura + 1 escritura. Y 3 copias del bucle que aplana `pages[*][key].items` → `collectPageItems` |
| `c0f962f` | 5 cálculos de relleno repetidos en el TUI → `rightAlign(left, right, w)` |
| `a7b5389` | `resolveScanDir` era `config.ResolveDir` sin `MkdirAll` → `ResolveDir(dir, create bool)`. Alias corto/largo de flags comparten variable vía `fs.BoolVar`. `qualityNames` era copia literal del map `qualities` → `downloader.Qualities` |
| `ca33ffc` | `default_folder`, `default_limit`, `email` y `password`: ningún lector. La **constante** `DefaultFolder` sí se usa y se queda |
| `8bc9cb4` | `safeGetStr`≡`nestedStr` y `getFloat`≡`nestedFloat` → dos accesores en vez de cuatro. `appendU32LE/BE` → `encoding/binary`. `isAlbumType` solo se llamaba con `"remaster"` → `isRemaster`. `renderFormat` compilaba su regex dentro del bucle por resultado |
| `aa035d3` | `GetFavoriteAlbums` sin llamantes; `NonStreamableError` declarado y nunca construido |

Compatibilidad al retirar claves de config: `writeINI` vuelca primero su lista ordenada y
luego el resto del mapa, así que un `config.ini` existente sigue cargando y conserva las
claves retiradas al reescribirse. Verificado con el binario contra un config viejo.

## Dos bugs encontrados por el camino

**`a1537db` — el TUI mezclaba idiomas.** Un usuario en inglés veía el menú en inglés pero
el pie de descarga, la lista vacía y los once mensajes del backend en español. 16 sitios
fuera de `T()`. Los mensajes de estado pasan a inglés + `T()`; los **errores** se quedan
en inglés sin `T()`, como los de `api`, `config` y `downloader` — traducir solo los del
backend TUI sería incoherente y los `%w` no son claves de tabla.

**`e714ef5` + `54e45e5` — ocho mensajes escribían a la terminal con las barras vivas.**
Con `mpb` renderizando corrompen el dibujo; bajo el TUI pintan encima de la alt-screen, y
`os.Stderr` cuenta igual que stdout porque la alt-screen se traga los dos.

Tres eran `fmt.Print*`: el aviso de carátula de `tagFLAC` (que corre desde el pool de
workers, el peor caso) más los "no tracks found" de `csvbatch.go` y `lastfm.go`. Los otros
cinco eran `os.Stderr` en `csvbatch.go`, tres de ellos dentro de `ParseCSV` — que corre
bajo el TUI vía `DownloadCSV`.

`tagFLAC` y `ParseCSV` reciben ahora un `io.Writer`, patrón que ya usaban `makeM3U` y
`printBatchSummary`. Y sale una regla: **un error que el usuario tiene que ver se
devuelve, no se imprime**. `DownloadCSV(...) error` y `runDisplay(..., fn func(ctx) error)
error` lo reportan con la pantalla ya cerrada — bajo el TUI el shell lo pinta en su línea
de estado, en CLI acaba en `fatalf` (stderr, exit 1). Lo que sí es un aviso ("could not
write failed report") va a `termOut()`: no debe enmascarar una descarga que sí funcionó.

## Lo que de verdad merece revisión: cuatro tests que pasaban con el bug delante

Este es el patrón que se repitió cuatro veces, y por qué los tests crecieron tanto:

- **`rightAlign` sin relleno** pasaba `TestMenuRendersFullySpanish` entero — ese test
  compara texto, no ancho. Test nuevo con aserción sobre `lipgloss.Width`.
- **`buildFLACPictureBlock` con `BigEndian`→`LittleEndian`** no rompía nada: la función
  nunca tuvo test. El swap a stdlib llegó con `TestBuildFLACPictureBlock`.
- **Los tres tests de i18n** tenían un agujero cada uno: `readUISources` leía una lista
  fija de seis ficheros y nunca miró `cmd/qobuz-dl/tui_cmd.go` (ahora lee por directorio);
  la regex solo miraba `ñÑ¿¡` y `"(vacío)"` pasaba; y el español sin ningún carácter
  distintivo (`"%d completadas"`) es invisible para cualquier escaneo de fuentes.
  `TestEnglishRenderStaysEnglish` renderiza en inglés y falla si aparece cualquier valor
  del mapa `es` — una cadena hardcodeada sale idéntica en los dos idiomas, y eso no
  necesita lista de palabras.
- **`TestTermOutDiscardsUnderTUI`** prueba que `termOut()` *devuelve* `io.Discard`, no que
  alguien lo *use*, así que los ocho pasaban. `TestNoDirectStdoutWrites` escanea el
  paquete buscando `fmt.Print*` y `os.Stdout`/`os.Stderr`, con `interactive.go` y
  `oauth.go` en allowlist. `csvbatch.go` además no tenía ningún test: los cuatro nuevos
  fijan el destino de los avisos y que un CSV ilegible sea un error mientras uno vacío no
  lo sea.

`TestAdvertisedFlagsExist` también reportó `--reset` como no registrado al pasar a
`fs.BoolVar`: no era un fallo del cambio, su regex solo conocía `fs.Bool/String/Int`.

Cada refactor validado rompiendo la línea a mano: 15 mutaciones en total, las 15 detectadas.

## Cobertura

| Paquete | Antes | Ahora |
|---|---|---|
| api | 42.3% | 42.9% |
| config | 37.9% | 45.1% |
| downloader | 41.5% | 48.7% |
| ui | 53.3% | 55.8% |

## Verificación

`gofmt -l`, `go build ./...`, `go vet ./...` y `go test -cover ./...` en verde tras cada
commit. Smoke manual del binario: `lyrics` sobre ruta inexistente sigue sin crear el
directorio, los alias corto/largo siguen equivalentes, y un `config.ini` con las cuatro
claves retiradas carga sin quejarse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
