### PR TITLE
fix(ui): la pantalla de descarga se borraba en cada anuncio de álbum

### DIFF
--- a/internal/ui/handle_test.go
+++ b/internal/ui/handle_test.go
@@ -245,3 +245,86 @@ func TestTrackHandleAbortFailureCarriesError(t *testing.T) {
 		t.Error("MsgFailed.Err is nil — the model has nothing to display")
 	}
 }
+
+// ---- multi-item runs (issue #18) ----------------------------------------
+
+func applyMsgs(m Model, msgs ...tea.Msg) Model {
+	for _, msg := range msgs {
+		out, _ := m.Update(msg)
+		m = out.(Model)
+	}
+	return m
+}
+
+// TestModelAccumulatesAcrossAnnouncements is the regression test for #18.
+//
+// downloadTrackByID announces every loose track with its own MsgAlbum{Tracks:1}
+// — that is the CSV import path, and the artist path does the same once per
+// album. MsgAlbum used to clear the track list and the counters, so the screen
+// showed one track at a time and the counter restarted on each song, which read
+// as "downloads are sequential" even where the worker pool was running fine.
+func TestModelAccumulatesAcrossAnnouncements(t *testing.T) {
+	cases := []struct {
+		name              string
+		msgs              []tea.Msg
+		wantTotal, wantN  int
+		wantDone, wantBad int
+	}{
+		{
+			name: "csv import: one announcement per track",
+			msgs: []tea.Msg{
+				MsgAlbum{Title: "a", Tracks: 1}, MsgRegisterTrack{ID: "1"}, MsgDone{ID: "1"},
+				MsgAlbum{Title: "b", Tracks: 1}, MsgRegisterTrack{ID: "2"}, MsgDone{ID: "2"},
+				MsgAlbum{Title: "c", Tracks: 1}, MsgRegisterTrack{ID: "3"},
+			},
+			wantTotal: 3, wantN: 3, wantDone: 2,
+		},
+		{
+			name: "artist discography: one announcement per album",
+			msgs: []tea.Msg{
+				MsgAlbum{Title: "LP1", Tracks: 2}, MsgRegisterTrack{ID: "1"}, MsgRegisterTrack{ID: "2"},
+				MsgAlbum{Title: "LP2", Tracks: 3}, MsgRegisterTrack{ID: "3"},
+			},
+			wantTotal: 5, wantN: 3,
+		},
+		{
+			name: "a failure is kept across the next announcement",
+			msgs: []tea.Msg{
+				MsgAlbum{Title: "a", Tracks: 1}, MsgRegisterTrack{ID: "1"}, MsgFailed{ID: "1"},
+				MsgAlbum{Title: "b", Tracks: 1}, MsgRegisterTrack{ID: "2"},
+			},
+			wantTotal: 2, wantN: 2, wantBad: 1,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := applyMsgs(NewModel(), c.msgs...)
+			if m.totalTracks != c.wantTotal {
+				t.Errorf("totalTracks = %d, want %d", m.totalTracks, c.wantTotal)
+			}
+			if len(m.tracks) != c.wantN {
+				t.Errorf("tracks listed = %d, want %d", len(m.tracks), c.wantN)
+			}
+			if m.done != c.wantDone {
+				t.Errorf("done = %d, want %d", m.done, c.wantDone)
+			}
+			if m.failed != c.wantBad {
+				t.Errorf("failed = %d, want %d", m.failed, c.wantBad)
+			}
+		})
+	}
+}
+
+// The counters must still start clean for each new run — that reset lives in
+// Shell.start (and runDisplay for --tui), which build a fresh Model.
+func TestNewModelStartsClean(t *testing.T) {
+	m := applyMsgs(NewModel(), MsgAlbum{Title: "a", Tracks: 4}, MsgRegisterTrack{ID: "1"}, MsgDone{ID: "1"})
+	if m.totalTracks == 0 || m.done == 0 {
+		t.Fatal("test setup did not accumulate anything")
+	}
+	if fresh := NewModel(); fresh.totalTracks != 0 || fresh.done != 0 || len(fresh.tracks) != 0 {
+		t.Errorf("NewModel carries state: total=%d done=%d tracks=%d",
+			fresh.totalTracks, fresh.done, len(fresh.tracks))
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -112,14 +112,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 
 	case MsgAlbum:
+		// The header follows whatever is being fetched right now, but the
+		// track list and counters accumulate: one run can cover many albums
+		// (an artist discography) or many loose tracks (a CSV import, where
+		// downloadTrackByID announces every single track). Clearing here made
+		// each announcement wipe the screen — the list showed one track at a
+		// time and the counter restarted on every song.
+		//
+		// Resetting belongs to the start of a run, and already happens there:
+		// Shell.start builds a fresh Model, and so does runDisplay for --tui.
 		m.album = msg.Title
 		m.artist = msg.Artist
 		m.format = msg.Format
-		m.totalTracks = msg.Tracks
-		m.tracks = nil
-		m.index = make(map[string]int)
-		m.done = 0
-		m.failed = 0
+		m.totalTracks += msg.Tracks
 
 	case MsgRegisterTrack:
 		e := trackEntry{


### PR DESCRIPTION
Closes #18 en su parte de visualización. **Queda una segunda causa sin arreglar**, descrita
al final: para imports CSV la descarga es secuencial de verdad.

## El bug

`MsgAlbum` no solo fijaba la cabecera, también reseteaba el estado entero del modelo:

```go
m.totalTracks = msg.Tracks
m.tracks = nil
m.index = make(map[string]int)
m.done = 0
m.failed = 0
```

Y `downloadTrackByID` (`track.go:99`) envía un `MsgAlbum{Tracks: 1}` **por cada track
suelto** — que es exactamente la ruta que recorre un import CSV, y la que recorren las
canciones encoladas desde la búsqueda del TUI.

El resultado es que cada canción borraba la pantalla. Reproducido antes de tocar nada:
tras registrar y completar 3 tracks, el modelo quedaba en

```
totalTracks=1  done=1  len(tracks)=1
```

Que es palabra por palabra lo que reporta la issue: *"doesn't show the total of tracks
being downloaded. When the song is fully downloaded the counter resets."*

Con discografías de artista pasaba lo mismo entre álbumes: `downloadAlbumCollection`
anuncia uno por álbum, así que la lista se vaciaba al pasar al siguiente.

## El arreglo

El total acumula y la lista se conserva; la cabecera sigue mostrando el trabajo en curso.

Lo que hace seguro quitar el reset es que **ya existía en el sitio correcto**: reiniciar
pertenece al arranque de una operación, no a cada álbum dentro de ella. `Shell.start`
(`shell.go:401`) construye un `Model` nuevo por operación, y `runDisplay` hace lo propio
en el camino `--tui`. El reset dentro de `MsgAlbum` era redundante ahí y activamente
dañino en todo lo demás.

## Tests

`TestModelAccumulatesAcrossAnnouncements` cubre los tres patrones de anuncio que produce
el downloader: uno por track (CSV), uno por álbum (discografía), y que un fallo sobreviva
al siguiente anuncio. `TestNewModelStartsClean` fija la otra mitad — que cada operación
sí empieza en cero — para que el arreglo no se convierta en contadores que nunca se
reinician.

Validado con 2 mutaciones (restaurar el reset, y volver `+=` a `=`), las 2 detectadas.
Cobertura de `ui` 55.8% → 59.1%.

## Lo que este PR NO arregla

La issue menciona *"downloads it one by one instead of downloading simultaneously"*, y hay
una segunda causa real detrás de esa frase: **`DownloadCSV` es un bucle secuencial**. El
pool de workers (`d.Opts.Workers`) solo lo usa `runTrackJobs`, la ruta de álbum; el import
CSV llama `downloadTrackByID` una vez por fila, sin concurrencia. Eso afecta por igual a la
CLI y al TUI.

Para **álbumes** la concurrencia siempre estuvo bien y es idéntica en ambos displays — no
hay ninguna rama por tipo de pantalla en `runTrackJobs`. Lo que hacía *parecer* secuencial
al TUI era este bug de repintado.

Paralelizar el CSV es un cambio aparte y con decisiones propias: lanza N búsquedas
simultáneas contra la API de Qobuz (riesgo de rate limit) y altera el orden de la salida y
del CSV de fallidos. Va en su propio PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
